### PR TITLE
Array header support

### DIFF
--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -166,11 +166,21 @@ Server.prototype.handle = function(req, res, outerNext) {
         var date = new Date;
         res.writeHead = writeHead;
         headers = headers || {};
-        headers["Date"] = date.toUTCString();
-        headers['X-Response-Time'] = (date - start) + "ms";
-        if (me.showVersion) {
-            headers["X-Powered-By"] = "Connect " + exports.version;
-            headers["Server"] = "Node " + process.version;
+        
+        if (headers instanceof Array) {
+            headers.push(['Date', date.toUTCString()]);
+            headers.push(['X-Response-Time', (date - start) + "ms"]);
+            if (me.showVersion) {
+                headers.push(["X-Powered-By", "Connect " + exports.version]);
+                headers.push(["Server",  "Node " + process.version]);
+            }
+        } else {
+            headers["Date"] = date.toUTCString();
+            headers['X-Response-Time'] = (date - start) + "ms";
+            if (me.showVersion) {
+                headers["X-Powered-By"] = "Connect " + exports.version;
+                headers["Server"] = "Node " + process.version;
+            }
         }
         res.writeHead(code, headers);
     };

--- a/lib/connect/middleware/session.js
+++ b/lib/connect/middleware/session.js
@@ -65,10 +65,14 @@ exports = module.exports = function sessionSetup(options){
             // Multiple Set-Cookie headers
             headers = headers || {};
             var cookie = utils.serializeCookie(key, req.sessionID, store.cookie);
-            if (headers['Set-Cookie']) {
-                headers['Set-Cookie'] += '\r\nSet-Cookie: ' + cookie;
+            if (headers instanceof Array) {
+                headers.push(['Set-Cookie', cookie]);
             } else {
-                headers['Set-Cookie'] = cookie;
+                if (headers['Set-Cookie']) {
+                    headers['Set-Cookie'] += '\r\nSet-Cookie: ' + cookie;
+                } else {
+                    headers['Set-Cookie'] = cookie;
+                }
             }
 
             // Pass through the writeHead call


### PR DESCRIPTION
Node's http server handles headers as an array as well as an object, which makes a nice interface for setting multiple Set-Cookie headers, for instance.

I recently found that the way connect wraps this is terribly buggy, since it treats the headers as definitely an object. I've attached a proposed fix as a pull request.

Additionally, I added a change to the session middleware to deal with array headers just as nicely.
