### PR TITLE
No vhost header

### DIFF
--- a/lib/connect/middleware/vhost.js
+++ b/lib/connect/middleware/vhost.js
@@ -33,6 +33,7 @@ module.exports = function vhost(hostname, server){
         throw new Error('vhost server required');
     }
     return function vhost(req, res, next){
+        if (!req.headers.host) next();
         var host = req.headers.host.split(':')[0];
         if (host === hostname) {
             server.handle(req, res, next);

--- a/test/vhost.test.js
+++ b/test/vhost.test.js
@@ -9,7 +9,7 @@ var connect = require('connect'),
     http = require('http');
 
 module.exports = {
-    test: function(){
+    'test with host': function(){
         var server = helpers.run(
             connect.vhost('foo.com', connect.createServer(
                 function(req, res){
@@ -40,6 +40,22 @@ module.exports = {
             res.addListener('end', function(){
                 assert.equal('from bar', res.body);
             });
+        });
+        req.end();
+    },
+    'test without host': function(){
+        var server = helpers.run(
+            connect.vhost('foo.com', connect.createServer(
+                function(req, res){
+                    res.writeHead(200, {});
+                    res.end('from foo');
+                }
+            ))
+        );
+        
+        var req = server.request('GET', '/');
+        req.addListener('response', function(res){
+            assert.equal(404, res.statusCode);
         });
         req.end();
     }


### PR DESCRIPTION
So my error log on my deployment server gets errors that look like this every so often:

```
TypeError: Cannot call method 'split' of undefined
    at Object.vhost [as handle] (/usr/local/lib/node/.npm/connect/0.2.4/package/lib/connect/middleware/vhost.js:36:37)
    at next (/usr/local/lib/node/.npm/connect/0.2.4/package/lib/connect/index.js:264:23)
    at Object.logger [as handle] (/usr/local/lib/node/.npm/connect/0.2.4/package/lib/connect/middleware/logger.js:114:9)
    at next (/usr/local/lib/node/.npm/connect/0.2.4/package/lib/connect/index.js:264:23)
    at Server.handle (/usr/local/lib/node/.npm/connect/0.2.4/package/lib/connect/index.js:277:5)
    at Server.emit (events:33:26)
    at HTTPParser.onIncoming (http:830:10)
    at HTTPParser.onHeadersComplete (http:87:31)
    at Stream.ondata (http:762:22)
    at IOWatcher.callback (net:494:29)
```

It was a tiny fix, and I added a test case to compliment it. Cheers!
