### PR TITLE
Checking lowercase headers in gzip

### DIFF
--- a/lib/connect/middleware/gzip-compress.js
+++ b/lib/connect/middleware/gzip-compress.js
@@ -25,12 +25,13 @@ module.exports = function gzip(){
             end = res.end;
 
         res.writeHead = function (code, headers) {
-            var type = headers["Content-Type"],
+            var type = headers["Content-Type"] || headers['content-type'],
+                encoding = headers['Content-Encoding'] || headers['content-encoding'],
                 accept = req.headers["accept-encoding"];
 
             if (!(code === 200 && accept && accept.indexOf('gzip') >= 0
                   && type && (/(text|javascript|json)/).test(type)
-                  && headers["Content-Encoding"] === undefined)) {
+                  && encoding === undefined)) {
                 res.writeHead = writeHead;
                 res.writeHead(code, headers);
                 return;

--- a/lib/connect/middleware/gzip-proc.js
+++ b/lib/connect/middleware/gzip-proc.js
@@ -26,12 +26,13 @@ module.exports = function gzip(){
             end = res.end;
 
         res.writeHead = function (code, headers) {
-            var type = headers["Content-Type"],
+            var type = headers["Content-Type"] || headers['content-type'],
+                encoding = headers['Content-Encoding'] || headers['content-encoding'],
                 accept = req.headers["accept-encoding"];
 
             if (!(code === 200 && accept && accept.indexOf('gzip') >= 0
                   && type && (/(text|javascript|json)/).test(type)
-                  && headers["Content-Encoding"] === undefined)) {
+                  && encoding === undefined)) {
                 res.writeHead = writeHead;
                 res.writeHead(code, headers);
                 return;


### PR DESCRIPTION
This patch fixes an issue I ran into when writing a node module that acted as a reverse proxy - since node's http.Client lowercases all headers, the headers being passed to connect's gzip handler were lowercase as well.  As the handler checks the first-letter-capitalized version of the headers, this resulted in some unexpected behavior (mostly requests that should be gzipped not being gzippped). 

As HTTP headers are supposed to be case-insensitive, the 100% correct thing to do would probably to be to run through the headers and checked the lowercase-ified version of all of them, but that seemed like a lot of overhead for not a lot of benefit.  I imagine just checking like this (e.g. "Content-Type" and "content-type") is good enough for 99% of the cases out there.
