### PR TITLE
Follow symlinks in the staticProvider.

### DIFF
--- a/lib/connect/middleware/staticProvider.js
+++ b/lib/connect/middleware/staticProvider.js
@@ -63,7 +63,7 @@ module.exports = function staticProvider(options){
     return function staticProvider(req, res, next) {
         if (req.method != 'GET' && req.method != 'HEAD') return next();
 
-        var hit, 
+        var hit,
             head = req.method == 'HEAD',
             filename, url = parseUrl(req.url);
 
@@ -79,7 +79,7 @@ module.exports = function staticProvider(options){
         if (filename[filename.length - 1] === '/') {
             filename += "index.html";
         }
-        
+
         // Cache hit
         if (cache && !conditionalGET(req) && (hit = _cache[req.url])) {
             res.writeHead(200, hit.headers);
@@ -87,7 +87,7 @@ module.exports = function staticProvider(options){
             return;
         }
 
-        fs.stat(filename, function(err, stat){
+        fs.lstat(filename, function(err, stat){
 
             // Pass through for missing files, thow error for other problems
             if (err) {
@@ -115,7 +115,7 @@ module.exports = function staticProvider(options){
                 if (!modified(req, headers)) {
                     return notModified(res, headers);
                 }
-                
+
                 res.writeHead(200, headers);
                 res.end(head ? undefined : data);
 
@@ -162,7 +162,7 @@ function modified(req, headers) {
             if (lastModified <= modifiedSince) return false;
         }
     }
-    
+
     return true;
 }
 


### PR DESCRIPTION
Tests still pass for the staticProvider. I didn't see a reason not to use lstat.
