### PR TITLE
request.originalUrl

### DIFF
--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -197,7 +197,9 @@ Server.prototype.handle = function(req, res, outerNext) {
 
     function next(err) {
         // Put the prefix back on if it was removed
-        req.url = req.originalUrl = removed + req.url;
+        req.url = removed + req.url;
+        // Only set originalUrl the first time
+        req.originalUrl = req.originalUrl || req.url;
         removed = "";
 
         var layer = stack[index++];


### PR DESCRIPTION
I discovered that when connect.Server instances get nested such that request.url is altered more than once, request.originalUrl gets replaced with the previous URL.
