### PR TITLE
Vhost undefined fix

### DIFF
--- a/lib/connect/middleware/vhost.js
+++ b/lib/connect/middleware/vhost.js
@@ -33,7 +33,7 @@ module.exports = function vhost(hostname, server){
         throw new Error('vhost server required');
     }
     return function vhost(req, res, next){
-        if (!req.headers.host) next();
+        if (!req.headers.host) return next();
         var host = req.headers.host.split(':')[0];
         if (host === hostname) {
             server.handle(req, res, next);


### PR DESCRIPTION
It must `return next()` if it's at the top of the middleware function, otherwise the stuff below occurs and the `cannot call method "split" of undefined` error still occurs.
