### PR TITLE
Allow middleware to modify req.params

### DIFF
--- a/lib/connect/middleware/router.js
+++ b/lib/connect/middleware/router.js
@@ -67,7 +67,7 @@ module.exports = function router(fn){
             self = this;
         (function pass(i){
             if (route = match(req, routes, i)) {
-                req.params = route._params;
+                req.params = req.params || route._params;
                 try { 
                     route.call(self, req, res, function(err){
                         if (err === true) {


### PR DESCRIPTION
I was working on a middleware app for an API I am working on and I needed to modify the req.params to the end route can use it. However, params is re-written on each route instead of skipping it if the req object already has a params array.
