### PR TITLE
Add support for standard `http.Server` instances in the 'vhost' middleware

### DIFF
--- a/lib/connect/middleware/vhost.js
+++ b/lib/connect/middleware/vhost.js
@@ -34,7 +34,7 @@ module.exports = function vhost(hostname, server){
         var host = req.headers.host.split(':')[0];
         if (req.subdomains = regexp.exec(host)) {
             req.subdomains = req.subdomains.slice(1);
-            server.handle(req, res, next);
+            server.emit("request", req, res, next);
         } else {
             next();
         }

--- a/test/vhost.test.js
+++ b/test/vhost.test.js
@@ -131,5 +131,25 @@ module.exports = {
             assert.equal(404, res.statusCode);
         });
         req.end();
+    },
+    
+    'test standard http server': function() {
+        var server = helpers.run(
+            connect.vhost('foo.com', http.createServer(
+                function(req, res){
+                    res.writeHead(200);
+                    res.end('from foo');
+                }
+            ))
+        );
+
+        var req = server.request('GET', '/', { Host: 'foo.com' });
+        req.buffer = true;
+        req.addListener('response', function(res){
+            res.addListener('end', function(){
+                assert.equal('from foo', res.body);
+            });
+        });
+        req.end();
     }
 }


### PR DESCRIPTION
This allows you to use a standard `http.Server` instance as the handler for the 'vhost' middleware, with a test case!

I was actually trying to use `node-http-proxy`'s server instance as a handler, so this will allow use of that (and any other subclasses of http.Server), as well.
