### PR TITLE
List man pages in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,20 @@
     { "name": "TJ Holowaychuk", "email": "tj@vision-media.ca" }
   ],
   "directories": { "lib": "./lib/connect" },
-  "engines": { "node": ">= 0.1.98" }
+  "engines": { "node": ">= 0.1.98" },
+  "man": [
+    "./docs/bodyDecoder.1",
+    "./docs/compiler.1",
+    "./docs/conditionalGet.1",
+    "./docs/cookieDecoder.1",
+    "./docs/errorHandler.1",
+    "./docs/index.1",
+    "./docs/jsonrpc.1",
+    "./docs/lint.1",
+    "./docs/logger.1",
+    "./docs/methodOverride.1",
+    "./docs/router.1",
+    "./docs/session.1",
+    "./docs/staticProvider.1"
+  ]
 }


### PR DESCRIPTION
Installing connect via npm doesn't install the man pages, since they're not listed anywhere in the package.json; this commit lists them there.

This doesn't entirely fix things, since to access the connect(1) man page you'd have to run `man connect-index`. To fix that index.1 should be renamed to connect.1 .

Also it might be better to put all the man pages in their own directory; then you'd just have to specify that directory instead of every single man page like this commit does.
