### PR TITLE
Secure session cookies should only be sent over HTTPS connections

### DIFF
--- a/lib/connect/middleware/session.js
+++ b/lib/connect/middleware/session.js
@@ -60,19 +60,26 @@ exports = module.exports = function sessionSetup(options){
                 store.set(req.sessionID, req.session);
             }
 
-            // Send an updated cookie to the browser
-            store.cookie.expires = new Date(Date.now() + store.maxAge);
+            // Only send secure session cookies when there is a secure connection.
+            // proxySecure is a custom attribute to allow for a reverse proxy to handle SSL connections and to
+            // communicate to connect over HTTP that the incoming connection is secure.
+            if ((store.cookie.secure
+                  && (req.connection.secure || req.connection.proxySecure))
+                  || !store.cookie.secure) {
+                // Send an updated cookie to the browser
+                store.cookie.expires = new Date(Date.now() + store.maxAge);
 
-            // Multiple Set-Cookie headers
-            headers = headers || {};
-            var cookie = utils.serializeCookie(key, req.sessionID, store.cookie);
-            if (headers instanceof Array) {
-                headers.push(['Set-Cookie', cookie]);
-            } else {
-                if (headers['Set-Cookie']) {
-                    headers['Set-Cookie'] += '\r\nSet-Cookie: ' + cookie;
+                // Multiple Set-Cookie headers
+                headers = headers || {};
+                var cookie = utils.serializeCookie(key, req.sessionID, store.cookie);
+                if (headers instanceof Array) {
+                    headers.push(['Set-Cookie', cookie]);
                 } else {
-                    headers['Set-Cookie'] = cookie;
+                    if (headers['Set-Cookie']) {
+                        headers['Set-Cookie'] += '\r\nSet-Cookie: ' + cookie;
+                    } else {
+                        headers['Set-Cookie'] = cookie;
+                    }
                 }
             }
 


### PR DESCRIPTION
As is, session.js will send secure session cookies over HTTP connections where as this should only occur over HTTPS connections. This patch addresses that concern.

It also allows for a reverse proxy to handle incoming SSL connections. A bit of connect middleware (e.g http://github.com/bartt/trust-reverse-proxy) could check for headers from a trusted reverse proxy and set req.connection.proxySecure.

Unfortunately one can not set req.connection.secure as this causes problems closing the HTTP connection between reverse proxy and node.
