### PR TITLE
Enable custom cookie expiration strategies

### DIFF
--- a/lib/connect/middleware/session.js
+++ b/lib/connect/middleware/session.js
@@ -42,6 +42,13 @@ exports = module.exports = function sessionSetup(options){
     // This should be set by the app to make the session key tamper proof
     var secret = options.secret || "hackme";
 
+    // By default session cookies expire the store's maximum age from now. By providing a custom function
+    // one can choose a different strategy, for example to allow the user to choose to be remembered. Return null to
+    // expire the cookie at the end of the browser session.
+    var expires = options.expires || function expires(req) {
+      return new Date(Date.now() + store.maxAge);
+    };
+
     return function sessionHandle(req, res, next) {
         if (!req.cookies) {
             next(new Error("session requires cookieDecoder to work properly"));
@@ -66,7 +73,7 @@ exports = module.exports = function sessionSetup(options){
             var secured = store.cookie.secure && (req.connection.secure || req.connection.proxySecure);
             if (secured || !store.cookie.secure) {
                 // Send an updated cookie to the browser
-                store.cookie.expires = new Date(Date.now() + store.maxAge);
+                store.cookie.expires = expires(req);
 
                 // Multiple Set-Cookie headers
                 headers = headers || {};


### PR DESCRIPTION
Added the option to provide a custom cookie expiration function.  By providing a custom function one can choose a different strategy,for example to allow the user to choose to be remembered. Return null to expire the cookie at the end of the browser session.

By default session cookies still expire the store's maximum age from now.
