### PR TITLE
Added autocompile and compress to compiler middleware

### DIFF
--- a/lib/connect/middleware/compiler.js
+++ b/lib/connect/middleware/compiler.js
@@ -61,9 +61,11 @@ var compilers = exports.compilers = {
  *
  * Options:
  *
- *   - `src`     Source directory, defaults to **CWD**.
- *   - `dest`    Destination directory, defaults `src`.
- *   - `enable`  Array of enabled compilers.
+ *   - `src`          Source directory, defaults to **CWD**.
+ *   - `dest`         Destination directory, defaults `src`.
+ *   - `enable`       Array of enabled compilers.
+ *   - `autocompile`  Autocompile the files every request. Ideal for development.
+ *   - `compress`     Get rid of the white spaces and comments.
  *
  * Compilers:
  *
@@ -79,6 +81,8 @@ module.exports = function compiler(options){
 
     var srcDir = process.connectEnv.compilerSrc || options.src || process.cwd(),
         destDir = process.connectEnv.compilerDest || options.dest || srcDir,
+        autocompile = options.autocompile || false,
+        will_compress = options.compress || false,
         enable = options.enable;
 
     if (!enable || enable.length === 0) {
@@ -112,7 +116,7 @@ module.exports = function compiler(options){
                                 }
                             } else {
                                 // Source has changed, compile it
-                                if (srcStats.mtime > destStats.mtime) {
+                                if (srcStats.mtime > destStats.mtime || autocompile) {
                                     compile();
                                 } else {
                                     // Defer file serving
@@ -133,6 +137,9 @@ module.exports = function compiler(options){
                                 if (err) {
                                     next(err);
                                 } else {
+                                    if(will_compress) {
+                                      str = compress(str);
+                                    }
                                     fs.writeFile(dest, str, 'utf8', function(err){
                                         next(err);
                                     });
@@ -141,6 +148,18 @@ module.exports = function compiler(options){
                         }
                     });
                 }
+
+                // Compress str
+                function compress(str) {
+                  str = str.replace(/[\n\r]*/mg,''); // blank lines
+                  str = str.replace(/\/\*.*?\*\//g,' '); // comments
+                  str = str.replace(/ +/g,' '); // more than one blank space
+                  str = str.replace(/: /g,':'); // usual spaces
+                  str = str.replace(/; /g,';'); // usual spaces
+                  str = str.replace(/ ?{ ?/g,'{'); // usual spaces
+                  return str;
+                }
+
                 return;
             }
         }


### PR DESCRIPTION
Given a file A.less

<pre>
@import "B.less";
</pre>

When I change B.less, A.less is not recompiled!

I added a option to the compiler so you can force the compilation for each request. Useful on a dev environment.

I also added a little dumb compressor.
