### PR TITLE
trivial patch for *.:format

### DIFF
--- a/lib/connect/middleware/router.js
+++ b/lib/connect/middleware/router.js
@@ -237,7 +237,7 @@ function normalizePath(path, keys) {
         + (optional || '');
     })
     .replace(/([\/.])/g, '\\$1')
-    .replace(/\*/g, '(.+)');
+    .replace(/\*/g, '(?:.+)');
   return new RegExp('^' + path + '$', 'i');
 }
 


### PR DESCRIPTION
I believe the regexp captures were off-by-one when using *.
