### PR TITLE
Add `watch` option to staticProvider

### DIFF
--- a/lib/connect/middleware/staticProvider.js
+++ b/lib/connect/middleware/staticProvider.js
@@ -31,6 +31,9 @@ var _cache = {};
  *   - `cache`    When true cache files in memory indefinitely,
  *                until invalidated by a conditional GET request.
  *                When given, maxAge will be derived from this value.
+ *   - `watch`    When truthy, cached files will be watched with fs.watchFile
+ *                and invalidated in the cache when updated. If this is
+ *                an object, it will be passed as options to fs.watchFile.
  *
  * @param {Object} options
  * @return {Function}
@@ -49,6 +52,7 @@ module.exports = function staticProvider(options){
         maxAge = options.maxAge;
         root = process.connectEnv.staticRoot || options.root || process.cwd();
         cache = options.cache;
+        watch = options.watch;
         if (cache && !maxAge) maxAge = cache;
         maxAge = maxAge || 0;
     }
@@ -119,6 +123,16 @@ module.exports = function staticProvider(options){
                         headers: headers,
                         body: data
                     };
+                    if (watch) {
+                      // Watch the file to invalidate cache if it changes.
+                      // NOTE: This may be undesirable for production use, please read:
+                      // http://groups.google.com/group/nodejs/browse_thread/thread/98939a501b98fdb8?tvc=2
+                      if ('object' !== typeof watch) watch = {};
+                      fs.watchFile(filename, watch, function() {
+                        delete(_cache[req.url]);
+                        fs.unwatchFile(filename);
+                      });
+                    }
                 }
             }
 


### PR DESCRIPTION
TL;DR: Use `fs.watchFile` to invalidate cached files when they change. Not intended for production use on non-Linux machines.

The problem: if you use staticProvider's cache, you have to restart the server to get new files. In production, and with standard deployment techniques (are they really "static" files if they're changing?), this isn't really a problem, but in some situations it may be desirable to update the cache when a file changes on the file system.

One approach (and the one that feels most Node-ish to me) is to simply use fs.watchFile to effectively subscribe to changes on a file when it gets cached, and if the file changes, invalidate the cache and kill the watcher.

Sadly, only Linux actually has an efficient implementation in libev for file watching, and every other system would just periodically stat().

So my concern with this change is that people might enable `watch` in production on non-Linux machines, and then wonder why their server is hitting the disk like one of those drinking birds. That would be bad. It still seems worth having the option, but I totally understand if this seems like a Pandora's box you don't want to open. I'd still recommend having some sort of hidden option to do it, in that case. Maybe just "_watch" instead of "watch", or something like "statAllTheTime", or "watchOutWhenYouUseThisOption". ;-)
