### PR TITLE
https support

### DIFF
--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -17,9 +17,17 @@ exports.version = '0.5.10';
 
 var fs = require('fs')
   , http = require('http')
-  , https = require('https')
   , assert = require('assert')
-  , parseUrl = require('url').parse;
+  , parseUrl = require('url').parse
+  , https = undefined;
+
+
+// continue to support pre 0.4 node.js versions before the https module
+try {
+    https = require('https')    
+} catch (err) {
+    console.log("https library does not exists, assuming node.js version is pre 0.4");
+}
 
 
 /**
@@ -274,9 +282,11 @@ Server.prototype.__proto__ = http.Server.prototype;
 Server.prototype.handle = handle;
 Server.prototype.use = use;
 
-SecureServer.prototype.__proto__ = https.Server.prototype;
-SecureServer.prototype.handle = handle;
-SecureServer.prototype.use = use;
+if (https) {
+    SecureServer.prototype.__proto__ = https.Server.prototype;
+    SecureServer.prototype.handle = handle;
+    SecureServer.prototype.use = use;    
+}
 
 /**
  * Shortcut for `new connect.Server([ ... ])`.


### PR DESCRIPTION
Hey, I added support for the new https module in 0.4 with continued support for pre-0.4 version of node.js, if the require('https') import fails. 

I'm having still working out tests which I'm having a few problems with but wanted to float this over incase you don't like the approach and thus the tests would be a waste. If you're good with the changes I can update the docs too.  Let me know...

Thanks,
Mike
