### PR TITLE
Wrong MIME type for index pages.

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -115,7 +115,7 @@ var send = exports.send = function(req, res, next, options){
   // parse url
   var url = parse(options.path)
     , path = decodeURIComponent(url.pathname)
-    , type = mime.lookup(path);
+    , type;
 
   // potentially malicious path
   if (~path.indexOf('..')) return fn
@@ -127,6 +127,7 @@ var send = exports.send = function(req, res, next, options){
 
   // index.html support
   if ('/' == path[path.length - 1]) path += 'index.html';
+  type = mime.lookup(path);
 
   fs.lstat(path, function(err, stat){
     // ignore ENOENT


### PR DESCRIPTION
Currently, connect is sending a MIME type of `application/octet-stream` for directory indexes.

This is because MIME type is detected before index.html is appended to the path.
