### PR TITLE
use stat instead of lstat in middlewares/static

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -131,7 +131,7 @@ var send = exports.send = function(req, res, next, options){
   // mime type
   type = mime.lookup(path);
 
-  fs.lstat(path, function(err, stat){
+  fs.stat(path, function(err, stat){
     // ignore ENOENT
     if (err) {
       if (fn) return fn(err);


### PR DESCRIPTION
any reason to use lstat? lstat gives you the physical size of the link instead of the linked file.
