### PR TITLE
Try node 0.4 querystring and fallback to qs

### DIFF
--- a/lib/middleware/bodyParser.js
+++ b/lib/middleware/bodyParser.js
@@ -10,7 +10,11 @@
  * Module dependencies.
  */
 
-var qs = require('qs');
+try {
+  var qs = require('querystring');
+} catch (e) {
+  var qs = require('qs');
+}
 
 /**
  * Extract the mime type from the given request's


### PR DESCRIPTION
node 0.4 has a querystring module that's a pluggable replacement for qs. http://nodejs.org/docs/v0.4.1/api/querystring.html

This commit uses querystring if available. If not, falls back to qs.
