### PR TITLE
Static mount option

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -104,6 +104,7 @@ var send = exports.send = function(req, res, next, options){
     , ranges = req.headers.range
     , head = 'HEAD' == req.method
     , root = options.root
+    , mount = options.mount
     , fn = options.callback;
 
   // replace next() with callback when available
@@ -117,6 +118,12 @@ var send = exports.send = function(req, res, next, options){
     , path = decodeURIComponent(url.pathname)
     , type;
 
+  // if there is a mount-option, check the path for it 
+  if (mount && path.substr(0, mount.length) !== mount) 
+    return next();
+  else
+    path = path.substr(mount.length);
+    
   // potentially malicious path
   if (~path.indexOf('..')) return fn
     ? fn(new Error('Forbidden'))

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -31,7 +31,20 @@ module.exports = {
          res.headers.should.have.property('etag');
      });
    },
+
+  'test mount': function(){
+    var app = connect.createServer(
+      connect.static(fixturesPath, { mount: '/mountPoint' })
+    );
     
+    assert.response(app,
+      { url: '/mountPoint/user.json' },
+      function(res){
+        res.statusCode.should.equal(200);
+        JSON.parse(res.body).should.eql({ name: 'tj', email: 'tj@vision-media.ca' });
+    });
+  },
+   
   'test maxAge': function(){
     var app = connect.createServer(
       connect.static(fixturesPath, { maxAge: 60000 })


### PR DESCRIPTION
this adds an option to the static-provider

```
var connect = require('./index.js')

var app = connect.createServer(
  connect.static(__dirname+'/public', {mount:'/mountPoint'})
).listen(8003)

// curl http://localhost:8003/mountPoint/index.html
```
