### PR TITLE
Fix small issues with reasonPhrase param in writeHead() proxies

### DIFF
--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -101,7 +101,10 @@ module.exports = function logger(options) {
         phrase = null;
       }
       res.writeHead = writeHead;
-      res.writeHead.apply(res, arguments);
+      if(phrase)
+        res.writeHead(code, phrase, headers);
+      else
+        res.writeHead(code, headers)
       res._statusCode = statusCode = code;
       resHeaders = headers || {};
     };

--- a/lib/middleware/responseTime.js
+++ b/lib/middleware/responseTime.js
@@ -22,11 +22,11 @@ module.exports = function responseTime(){
     res._responseTime = true;
 
     // proxy writeHead to calculate duration
-    res.writeHead = function(status, headers){
+    res.writeHead = function(status, phrase, headers){
       var duration = new Date - start;
       res.setHeader('X-Response-Time', duration + 'ms');
       res.writeHead = writeHead;
-      res.writeHead.apply(res, arguments);
+      res.writeHead(status, phrase, headers);
     };
 
     next();

--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -218,7 +218,7 @@ function session(options){
 
     // proxy writeHead() to Set-Cookie
     var writeHead = res.writeHead;
-    res.writeHead = function(status, headers){
+    res.writeHead = function(status, phrase, headers){
       if (req.session) {
         var cookie = req.session.cookie;
         // only send secure session cookies when there is a secure connection.
@@ -233,7 +233,7 @@ function session(options){
 
       res.writeHead = writeHead;
       
-      return res.writeHead.apply(res, arguments);
+      return res.writeHead(status, phrase, headers);
     };
 
     // proxy end() to commit the session


### PR DESCRIPTION
Hi,

A little thing that tripped me up tonight -- some bits of middleware that didn't work right when trying to use the optional 2nd arg to `serverResponse.writeHead()`.

In logger's case, it would assume it's a header; thus discarding the headers you were trying to set, and not providing useful info in the log output.
