### PR TITLE
adds support for user callback to pull session key from request

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -190,8 +190,7 @@ function session(options){
     , store = options.store || new MemoryStore
     , fingerprint = options.fingerprint || defaultFingerprint
     , cookie = options.cookie
-    , get_key = options.get_key;
-
+    , sidInParam = options.sidInParam;
   // notify user that this store is not
   // meant for a production environment
   if ('production' == env && store instanceof MemoryStore) {
@@ -270,14 +269,12 @@ function session(options){
       req.session.cookie = new Cookie(cookie);
     };
 
-    // get the sessionID, either from user-defined function
-    // or by default from the cookie
-    if (get_key) {
-      req.sessionID = get_key(req, key);
-    } else {
-      req.sessionID = req.cookies[key];
+    // get the sessionID, either from cookie or from query param
+    req.sessionID = req.cookies[key];
+    if (!req.sessionID && req.param(key) && sidInParam) {
+      req.sessionID = req.param(key);
     }
-
+        
     // make a new session if the browser doesn't send a sessionID
     if (!req.sessionID) {
       generate();


### PR DESCRIPTION
hey guys,

i recently found myself in the position of wanting to put a request's session key in the request parameters rather than in a cookie. This was in the context of writing a test client for a RESTful application, where i'm switching sessions quite a lot- it felt somewhat cleaner to treat the session key as a parameter, rather than something special that requires its own header.

i added a few lines of code to the session middleware which lets the constructor accept a 'get_key' option, which should be a callback to be called when connect wants its session key. if nothing is specified, the default behavior is retained (that is, just use the cookie).

thanks!
