### PR TITLE
logger format token testcoverage

### DIFF
--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -10,7 +10,67 @@ var connect = require('connect')
   , fs = require('fs');
 
 module.exports = {
-  'test http remoteAddress logging': function(){
+  'test http :req[header]': function(){
+    var logLine = ''
+      , app = connect.createServer(
+          connect.logger({
+            format: ':req[foo]',
+            stream: { write: function(line){ logLine = line; } }
+          })
+        );
+
+    assert.response(app,
+      { url: '/', headers: { Foo: 'Bar' } },
+      function(){
+        assert.equal(logLine, 'Bar\n');
+      });
+  },
+  'test http :res[header]': function(){
+    var logLine = ''
+      , app = connect.createServer(
+          connect.logger({
+            format: ':res[content-type]',
+            stream: { write: function(line){ logLine = line; } }
+          })
+        );
+
+    assert.response(app,
+      { url: '/', headers: { Foo: 'Bar' } },
+      function(){
+        assert.equal(logLine, 'text/plain\n');
+      });
+  },
+  'test http :http-version': function(){
+    var logLine = ''
+      , app = connect.createServer(
+          connect.logger({
+            format: ':http-version',
+            stream: { write: function(line){ logLine = line; } }
+          })
+        );
+
+    assert.response(app,
+      { url: '/' },
+      function(){
+        assert.equal(logLine, '1.1\n');
+      });
+  },
+  'test http :response-time': function(){
+    var logLine = ''
+      , app = connect.createServer(
+          connect.logger({
+            format: ':response-time',
+            stream: { write: function(line){ logLine = line; } }
+          })
+        );
+
+    assert.response(app,
+      { url: '/' },
+      function(){
+        assert.type(parseInt(logLine, 10), 'number');
+      });
+  },
+  'test http :remote-addr': function(){
     var logLine = ''
       , app = connect.createServer(
           connect.logger({
@@ -25,7 +85,101 @@ module.exports = {
         assert.equal(logLine, '127.0.0.1\n');
       });
   },
-  'test https remoteAddress logging': function(){
+  'test http :date': function(){
+    var logLine = ''
+      , app = connect.createServer(
+          connect.logger({
+            format: ':date',
+            stream: { write: function(line){ logLine = line; } }
+          })
+        );
+
+    assert.response(app,
+      { url: '/'},
+      function(){
+        assert.doesNotThrow(function(){
+          new Date(logLine);
+        });
+        assert.type(Date.parse(logLine.replace('\n', '')), 'number');
+      });
+  },
+  'test http :method': function(){
+    var logLine = ''
+      , app = connect.createServer(
+          connect.logger({
+            format: ':method',
+            stream: { write: function(line){ logLine = line; } }
+          })
+        );
+
+    assert.response(app,
+      { method: 'post', url: '/' },
+      function(){
+        assert.equal(logLine, 'POST\n');
+      });
+  },
+  'test http :url': function(){
+    var logLine = ''
+      , app = connect.createServer(
+          connect.logger({
+            format: ':url',
+            stream: { write: function(line){ logLine = line; } }
+          })
+        );
+
+    assert.response(app,
+      { url: '/foo/bar?baz=equals&the#ossom' },
+      function(){
+        assert.equal(logLine, '/foo/bar?baz=equals&the#ossom\n');
+      });
+  },
+  'test http :referrer': function(){
+    var logLine = ''
+      , app = connect.createServer(
+          connect.logger({
+            format: ':referrer',
+            stream: { write: function(line){ logLine = line; } }
+          })
+        );
+
+    assert.response(app,
+      { url: '/', headers: { referrer: 'http://google.com' } },
+      function(){
+        assert.equal(logLine, 'http://google.com\n');
+      });
+  },
+  'test http :user-agent': function(){
+    var logLine = ''
+      , app = connect.createServer(
+          connect.logger({
+            format: ':user-agent',
+            stream: { write: function(line){ logLine = line; } }
+          })
+        );
+
+    assert.response(app,
+      { url: '/', headers: { 'user-agent': 'FooBarClient 1.1.0' } },
+      function(){
+        assert.equal(logLine, 'FooBarClient 1.1.0\n');
+      });
+  },
+  'test http :status': function(){
+    var logLine = ''
+      , app = connect.createServer(
+          connect.logger({
+            format: ':status',
+            stream: { write: function(line){ logLine = line; } }
+          })
+        );
+
+    assert.response(app,
+      { url: '/' },
+      function(){
+        assert.equal(logLine, '404\n');
+      });
+  },
+  // https regression tests
+  'test https :remote-addr': function(){
     var logLine = ''
       , app = connect.createServer(
           {


### PR DESCRIPTION
Followed the way of having one test per token. A https version of a tests only should be needed in the case of a regression where :remote-addr is a good example.
