### PR TITLE
Letting devs overwite the hash function in a session store.

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -252,18 +252,20 @@ function session(options){
     };
 
     // session hashing function
-    function hash(base) {
-      return crypto
+    if (!(store.hash)) {
+      store.hash = function(base) {
+        return crypto
         .createHmac('sha256', secret)
         .update(base + fingerprint(req))
-        .digest('base64')
+        .digest('hex')
         .replace(/=*$/, '');
+      }
     }
 
     // generates the new session
     var generate = store.generate = function(){
       var base = utils.uid(24);
-      var sessionID = base + '.' + hash(base);
+      var sessionID = base + '.' + store.hash(base);
       req.sessionID = sessionID;
       req.session = new Session(req);
       req.session.cookie = new Cookie(cookie);
@@ -281,7 +283,7 @@ function session(options){
 
     // check the fingerprint
     var parts = req.sessionID.split('.');
-    if (parts[1] != hash(parts[0])) {
+    if (parts[1] != store.hash(parts[0])) {
       generate();
       next();
       return;


### PR DESCRIPTION
Signed-off-by: Nick Campbell nicholas.j.campbell@gmail.com

I wasn't entirely sure how to go about testing this, with the way the system is currently set up, since the hash is based on a semi-random uid. However, this will at least let devs overwrite the hash function. Generate cannot yet be overwritten.
