### PR TITLE
Fix for nested array bug in Set-Cookie header when multiple copies of connect are loaded

### DIFF
--- a/lib/patch.js
+++ b/lib/patch.js
@@ -32,9 +32,11 @@ res.setHeader = function(field, val){
   // special-case Set-Cookie
   if (this._headers && 'set-cookie' == key) {
     if (prev = this.getHeader(field)) {
-      val = Array.isArray(prev)
-        ? prev.concat(val)
-        : [prev, val];
+      if (!Array.isArray(val)) {
+        val = Array.isArray(prev)
+          ? prev.concat(val)
+          : [prev, val];
+      }
     }
   // charset
   } else if ('content-type' == key && this.charset) {


### PR DESCRIPTION
I think this one does fix the bug.
