### PR TITLE
Don't overwrite already set Content-Type in static.js middleware

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -187,8 +187,10 @@ var send = exports.send = function(req, res, next, options){
     }
 
     // transfer
-    var charset = mime.charsets.lookup(type);
-    res.setHeader('Content-Type', type + (charset ? '; charset=' + charset : ''));
+    if (!res.getHeader('content-type')) {
+      var charset = mime.charsets.lookup(type);
+      res.setHeader('Content-Type', type + (charset ? '; charset=' + charset : ''));
+    }
     res.setHeader('Accept-Ranges', 'bytes');
 
     if (head) return res.end();

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -203,5 +203,23 @@ module.exports = {
     assert.response(app,
       { url: '/script.coffee' },
       { headers: { 'Content-Type': 'application/coffee-script' }});
-  }
+  },
+  
+  'test do not override Content-Type header': function(){
+     var app = connect.createServer(
+       function(req, res, next){
+         res.setHeader('Content-Type', 'text/bozo; charset=ISO-8859-1');
+         next();
+       },
+       connect.static(fixturesPath)
+     );
+     
+     assert.response(app,
+       { url: '/' },
+       { body: '<p>Wahoo!</p>'
+       , status: 200
+       , headers: {
+         'Content-Type': 'text/bozo; charset=ISO-8859-1'
+       }});
+   }
 };


### PR DESCRIPTION
Updated static.js middleware so that it won't overwrite the Content-Type header if it is already set for a response. Also added a test for this case to static.test.js. Note that this is useful in the case where the file extension does not match the content type, such as for a gzipped file.
