### PR TITLE
Robustify errorHandler middleware for missing stack traces.

### DIFF
--- a/lib/middleware/errorHandler.js
+++ b/lib/middleware/errorHandler.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - errorHandler
  * Copyright(c) 2010 Sencha Inc.
@@ -62,7 +61,7 @@ exports = module.exports = function errorHandler(options){
       if (~accept.indexOf('html')) {
         fs.readFile(__dirname + '/../public/style.css', 'utf8', function(e, style){
           fs.readFile(__dirname + '/../public/error.html', 'utf8', function(e, html){
-            var stack = err.stack
+            var stack = (err.stack || '')
               .split('\n').slice(1)
               .map(function(v){ return '<li>' + v + '</li>'; }).join('');
               html = html


### PR DESCRIPTION
I've run into this case a couple of times where some error (usually a custom-thrown error from some view engine or compilation language) has no `stack` property, so the error handling middleware chokes on it. I found the line responsible and fixed it.
