### PR TITLE
Check for "/" path before joining on root directory for Win32 compatiblity in static middleware

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -130,12 +130,12 @@ var send = exports.send = function(req, res, next, options){
   if (~path.indexOf('..')) return fn
     ? fn(new Error('Forbidden'))
     : forbidden(res);
+    
+  // index.html support
+  if ('/' == path[path.length - 1]) path += 'index.html';
 
   // join from optional root dir
   path = join(options.root, path);
-
-  // index.html support
-  if ('/' == path[path.length - 1]) path += 'index.html';
 
   // "hidden" file
   if (!hidden && '.' == basename(path)[0]) return next();


### PR DESCRIPTION
Windows paths use backslashes instead of forward slashes, so the "index.html" will not be served when using static middleware.
