### PR TITLE
rearrange middleware

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -123,6 +123,15 @@ Server.prototype.use = function(route, handle){
     route = route.substr(0, route.length - 1);
   }
 
+	// rebuild the stack, removing this route if it's already there ...
+	var old = this.stack;
+	this.stack=[];
+	while (old.length) {
+		var nxtr = old.shift();
+		if (nxtr.handle != handle || nxtr.route != route)
+			this.stack.push(nxtr);
+	}
+
   // add the middleware
   this.stack.push({ route: route, handle: handle });
 


### PR DESCRIPTION
as discussed very briefly on the irc channel and the list.
I can see two things that need your consideration:
1. I might have misunderstood the terse instructions to not touch app.stack :
    that's precisely what I wanted to do, and I figured it meant the caller doesn't want to have to touch it.
2. I might be seriously overlooking some valid use case where identical middleware is duplicated in the stack - I'm relying on your expertise & foresight on that question.
