### PR TITLE
Add Stylus CSS to bundled compilers

### DIFF
--- a/lib/middleware/compiler.js
+++ b/lib/middleware/compiler.js
@@ -33,6 +33,7 @@ var cache = {};
  *
  *   - `sass`   Compiles cass to css
  *   - `less`   Compiles less to css
+ *   - `stylus` Compiles stylus to css
  *   - `coffeescript`   Compiles coffee to js
  *
  * @param {Object} options
@@ -120,6 +121,7 @@ exports = module.exports = function compiler(options){
  *
  *  - [sass](http://github.com/visionmedia/sass.js) to _css_
  *  - [less](http://github.com/cloudhead/less.js) to _css_
+ *  - [stylus](http://github.com/learnboost/stylus) to _css_
  *  - [coffee](http://github.com/jashkenas/coffee-script) to _js_
  */
 
@@ -143,6 +145,18 @@ var compilers = exports.compilers = {
       var less = cache.less || (cache.less = require('less'));
       try {
         less.render(str, fn);
+      } catch (err) {
+        fn(err);
+      }
+    }
+  },
+  stylus: {
+    match: /\.css$/,
+    ext: '.styl',
+    compile: function(str, fn){
+      var stylus = cache.stylus || (cache.stylus = require('stylus'));
+      try {
+        stylus.render(str, fn);
       } catch (err) {
         fn(err);
       }


### PR DESCRIPTION
Simple patch, just adding Stylus to bundled compilers, in exactly the same manner as the other three.
