### PR TITLE
Normalize root path in `connect.static()` when checking for malicious path

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -133,7 +133,7 @@ var send = exports.send = function(req, res, next, options){
   path = normalize(join(options.root, path));
 
   // malicious path
-  if (root && 0 != path.indexOf(root)) return fn
+  if (root && 0 != path.indexOf(normalize(root))) return fn
     ? fn(new Error('Forbidden'))
     : forbidden(res);
     


### PR DESCRIPTION
Hi!

I have some test cases which run from a subfolder and the root path is given as __dirname + "/.."
Connect gives forbidden result in malicious path check since the path to check is normalized but the root path is not. This change normalizes the root path in malicious path check.

BR,
Tomi
