### PR TITLE
The commonly held belief is that cookie values must be URL-encoded, but t

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - utils
  * Copyright(c) 2010 Sencha Inc.
@@ -143,7 +142,11 @@ exports.parseCookie = function(str){
 
     // Only assign once
     if (obj[key] === undefined) {
-      obj[key] = decodeURIComponent(val.replace(/\+/g, ' '));
+      try {
+        obj[key] = decodeURIComponent(val.replace(/\+/g, ' '));
+      } catch (e) {
+        obj[key] = val;
+      }
     }
   }
   return obj;


### PR DESCRIPTION
The commonly held belief is that cookie values must be URL-encoded, but this is a fallacy even though it is the de facto implementation. The original specification indicates that only three types of characters must be encoded: semicolon, comma, and white space. The specification indicates that URL encoding may be used but stops short of requiring it. The RFC makes no mention of encoding whatsoever. 
