### PR TITLE
Remove Chrome Frame UA token from user-agent string used in default fingerprint function.

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -50,7 +50,8 @@ var warning = 'Warning: connection.session() MemoryStore is not\n'
  */
 
 function defaultFingerprint(req) {
-  return req.headers['user-agent'] || '';
+  // Remove chromeframe token from the user agent string if present.
+  return (req.headers['user-agent'] || '').replace(/;?\schromeframe\/[\d\.]+/, "");
 };
 
 /**

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -638,9 +638,73 @@ module.exports = {
   
     http.get(options, function(res){
       var prev = sid(res);
+      options.headers['Cookie'] = 'connect.sid=' + prev;
       options.headers['User-Agent'] = 'tobi/1.0';
       http.get(options, function(res){
         prev.should.not.equal(sid(res));
+        --pending || app.close();
+      });
+    });
+  },
+  
+  'test chromeframe UA strings': function(){
+    ++pending;
+  
+    var options = {
+        port: port
+      , headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; BOIE9;ENUS)'
+      }
+    };
+  
+    http.get(options, function(res){
+      var prev = sid(res);
+      options.headers['Cookie'] = 'connect.sid=' + prev;
+      options.headers['User-Agent'] = 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; BOIE9;ENUS; chromeframe/12.0.742.100)';
+      http.get(options, function(res){
+        prev.should.equal(sid(res));
+        --pending || app.close();
+      });
+    });
+  },
+  
+  'test chromeframe sub resource request UA string': function(){
+    ++pending;
+  
+    var options = {
+        port: port
+      , headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/534.18 (KHTML, like Gecko) Chrome/11.0.660.0 Safari/534.18'
+      }
+    };
+  
+    http.get(options, function(res){
+      var prev = sid(res);
+      options.headers['Cookie'] = 'connect.sid=' + prev;
+      options.headers['User-Agent'] = 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; chromeframe/11.0.660.0) AppleWebKit/534.18 (KHTML, like Gecko) Chrome/11.0.660.0 Safari/534.18';
+      http.get(options, function(res){
+        prev.should.equal(sid(res));
+        --pending || app.close();
+      });
+    });
+  },
+  
+  'test chromeframe request rare token placement UA string': function(){
+    ++pending;
+  
+    var options = {
+        port: port
+      , headers: {
+        'User-Agent': 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)'
+      }
+    };
+  
+    http.get(options, function(res){
+      var prev = sid(res);
+      options.headers['Cookie'] = 'connect.sid=' + prev;
+      options.headers['User-Agent'] = 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) chromeframe/11.0.660.0';
+      http.get(options, function(res){
+        prev.should.equal(sid(res));
         --pending || app.close();
       });
     });


### PR DESCRIPTION
Changes to strip out the ChromeFrame token.  This should resolve issue #305 https://github.com/senchalabs/connect/issues/305
- Added tests for 3 different placements of the chromeframe token within a user agent string. 
- Updated the existing UA string test to set the session id on the cookie. Without this, the test will always pass even if the UA strings are equal
- Added regex to replace the chromeframe token with an empty string.
