### PR TITLE
Malformed cookies throw URIError: URI malformed

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -143,7 +143,16 @@ exports.parseCookie = function(str){
 
     // Only assign once
     if (obj[key] === undefined) {
-      obj[key] = decodeURIComponent(val.replace(/\+/g, ' '));
+      var withSpaces = val.replace(/\+/g, ' ');
+      try {
+        obj[key] = decodeURIComponent(withSpaces);
+      } catch (e) {
+        if (e instanceof URIError) {
+          obj[key] = withSpaces;
+        } else {
+          throw e;
+        }
+      }
     }
   }
   return obj;

--- a/test/cookieParser.test.js
+++ b/test/cookieParser.test.js
@@ -31,5 +31,11 @@ module.exports = {
     assert.response(app,
       { url: '/', headers: { Cookie: ['sid=123', 'name=tj'] }},
       { body: '{"sid":"123","name":"tj"}' });
+  },
+
+  'test malformed cookie': function() {
+    assert.response(app,
+      { url: '/', headers: { Cookie: ['sid=%g23'] }},
+      { body: '{"sid":"%g23"}' });
   }
 };


### PR DESCRIPTION
When parsing badly formed cookies, the parseCookie function can throw an exception. I don't _think_ this is desirable - it causes 500 errors in express's cookie parser middleware, but I grant that that could be as much their problem as connect's problem.

But there's no explicit contract for parseCookie, and this seems reasonable.
