### PR TITLE
Fix links in directory middleware when mounted at a sub-URL.

### DIFF
--- a/lib/middleware/directory.js
+++ b/lib/middleware/directory.js
@@ -56,6 +56,8 @@ exports = module.exports = function directory(root, options){
       , url = parse(req.url)
       , dir = decodeURIComponent(url.pathname)
       , path = normalize(join(root, dir))
+      , originalUrl = parse(req.originalUrl)
+      , originalDir = decodeURIComponent(originalUrl.pathname)
       , showUp = path != root && path != root + '/';
 
     // malicious path
@@ -76,7 +78,7 @@ exports = module.exports = function directory(root, options){
         // content-negotiation
         for (var key in exports) {
           if (~accept.indexOf(key) || ~accept.indexOf('*/*')) {
-            exports[key](req, res, files, next, dir, showUp, icons);
+            exports[key](req, res, files, next, originalDir, showUp, icons);
             return;
           }
         }


### PR DESCRIPTION
Use req.originalDir for directory links so that they work when the middleware is mounted at a sub-URL.
