### PR TITLE
Tentative support for node 0.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "High performance middleware framework",
   "keywords": ["framework", "web", "middleware", "connect", "rack"],
   "repository": "git://github.com/senchalabs/connect.git",
@@ -20,5 +20,5 @@
     "should": "0.2.1"
   },
   "main": "index",
-  "engines": { "node": ">= 0.4.1 < 0.5.0" }
+  "engines": { "node": ">= 0.4.1 < 0.6.0" }
 }


### PR DESCRIPTION
Any chance that the npm package could support node 0.5.0?

I have been playing with 0.5.0-pre for a while (along with express) as I experiment with SPDY and have not run into any issues.
