### PR TITLE
errorHandler middleware: Don't hardcode a status code of 500, use err.statusCode if set.

### DIFF
--- a/lib/middleware/errorHandler.js
+++ b/lib/middleware/errorHandler.js
@@ -53,7 +53,7 @@ exports = module.exports = function errorHandler(options){
     , formatUrl = options.formatUrl;
 
   return function errorHandler(err, req, res, next){
-    res.statusCode = 500;
+    res.statusCode = err.statusCode || 500;
     if (dumpExceptions) console.error(err.stack);
     if (showStack) {
       var accept = req.headers.accept || '';
@@ -68,6 +68,7 @@ exports = module.exports = function errorHandler(options){
                 .replace('{style}', style)
                 .replace('{stack}', stack)
                 .replace('{title}', exports.title)
+                .replace('{statusCode}', res.statusCode)
                 .replace(/\{error\}/g, utils.escape(err.toString()));
               res.setHeader('Content-Type', 'text/html');
               res.end(html);
@@ -80,7 +81,7 @@ exports = module.exports = function errorHandler(options){
         res.end(json);
       // plain text
       } else {
-        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.writeHead(res.statusCode, { 'Content-Type': 'text/plain' });
         res.end(err.stack);
       }
     } else {

--- a/lib/public/error.html
+++ b/lib/public/error.html
@@ -6,7 +6,7 @@
   <body>
     <div id="wrapper">
       <h1>{title}</h1>
-      <h2><em>500</em> {error}</h2>
+      <h2><em>{statusCode}</em> {error}</h2>
       <ul id="stacktrace">{stack}</ul>
     </div>
   </body>


### PR DESCRIPTION
I'm working on an application where most of my error objects come with an HTTP status code baked in, and especially in development mode it'd be really convenient if I could use the errorHandler middleware to do the actual error reporting (nice stack traces), but still have the right HTTP status code set.

The attached patch leverages `res.statusCode` which seems to be applicable here. From the 0.4.10 HTTP docs:

```
response.statusCode
When using implicit headers (not calling response.writeHead() explicitly), this property controls the status code that will be send to the client when the headers get flushed.
```
