### PR TITLE
Fix parsing of basic auth credentials if the password includes ':'.

### DIFF
--- a/lib/middleware/basicAuth.js
+++ b/lib/middleware/basicAuth.js
@@ -68,8 +68,12 @@ module.exports = function basicAuth(callback, realm) {
       , scheme = parts[0]
       , credentialsStr = new Buffer(parts[1], 'base64').toString()
       , idx = credentialsStr.indexOf(':')
-      , credentials = [credentialsStr.slice(0, idx), credentialsStr.slice(idx+1)];
-    if (-1 === idx) throw new Error('invalid Authorization header');
+      , credentials;
+    if (idx === -1) {
+      credentials = [credentialsStr];
+    } else {
+      credentials = [credentialsStr.slice(0, idx), credentialsStr.slice(idx+1)];
+    }
 
     if ('Basic' != scheme) return badRequest(res);
 

--- a/test/basicAuth.test.js
+++ b/test/basicAuth.test.js
@@ -11,7 +11,8 @@ var connect = require('connect')
 
 var app = connect(
   connect.basicAuth(function(user, pass){
-    return 'tj' == user && 'tobi' == pass;
+    return (('tj' == user && 'tobi' == pass)
+      || ('trent' == user && 'my:cat' == pass));
   }),
   function(req, res){
     res.end('wahoo');
@@ -70,6 +71,12 @@ module.exports = {
   'test authorized': function(){
     assert.response(app,
       { url: '/', headers: { Authorization: 'Basic dGo6dG9iaQ==' }},
+      { body: 'wahoo', status: 200 });
+  },
+
+  'test authorized with colon in password': function(){
+    assert.response(app,
+      { url: '/', headers: { Authorization: 'Basic dHJlbnQ6bXk6Y2F0' }},
       { body: 'wahoo', status: 200 });
   },
   


### PR DESCRIPTION
The current basic auth middleware will incorrect parse "user:password" for if the password includes a colon.

I'd love to see a 1.6.1 with this. :) Thanks.
