### PR TITLE
vhost hostname should be case-insensitive

### DIFF
--- a/lib/middleware/vhost.js
+++ b/lib/middleware/vhost.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - vhost
  * Copyright(c) 2010 Sencha Inc.
@@ -29,7 +28,7 @@
 module.exports = function vhost(hostname, server){
   if (!hostname) throw new Error('vhost hostname required');
   if (!server) throw new Error('vhost server required');
-  var regexp = new RegExp('^' + hostname.replace(/[*]/g, '(.*?)') + '$');
+  var regexp = new RegExp('^' + hostname.replace(/[*]/g, '(.*?)') + '$', 'i');
   if (server.onvhost) server.onvhost(hostname);
   return function vhost(req, res, next){
     if (!req.headers.host) return next();


### PR DESCRIPTION
Some browsers, Android Browser, for example, do not automatically toLowerCase() the url before sending it (Firefox and Chrome do).

vhost should match in a case-insensitive fashion.

=)
