### PR TITLE
rawBody should be set regardless of whether there is a parser set

### DIFF
--- a/lib/middleware/bodyParser.js
+++ b/lib/middleware/bodyParser.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - bodyParser
  * Copyright(c) 2010 Sencha Inc.
@@ -57,21 +56,25 @@ function mime(req) {
 exports = module.exports = function bodyParser(){
   return function bodyParser(req, res, next) {
     if ('GET' == req.method || 'HEAD' == req.method) return next();
-    var parser = exports.parse[mime(req)];
-    if (parser && !req.body) {
+    if (!req.body) {
       var data = '';
       req.setEncoding('utf8');
       req.on('data', function(chunk) { data += chunk; });
       req.on('end', function(){
         req.rawBody = data;
-        try {
-          req.body = data
-            ? parser(data)
-            : {};
-        } catch (err) {
-          return next(err);
+        var parser = exports.parse[mime(req)];
+        if(parser) {
+          try {
+            req.body = data
+              ? parser(data)
+              : {};
+          } catch (err) {
+            return next(err);
+          }
+          next();
+        } else {
+          next();
         }
-        next();
       });
     } else {
       next();


### PR DESCRIPTION
rawBody, which isn't parsed at all, should be set regardless of the parser or mime type
