### PR TITLE
ability to force Cache-Control and Last-Modified header fields before send a file

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -182,8 +182,8 @@ var send = exports.send = function(req, res, next, options){
     // stream the entire file
     } else {
       res.setHeader('Content-Length', stat.size);
-      res.setHeader('Cache-Control', 'public, max-age=' + (maxAge / 1000));
-      res.setHeader('Last-Modified', stat.mtime.toUTCString());
+      if (!res.getHeader('Cache-Control')) res.setHeader('Cache-Control', 'public, max-age=' + (maxAge / 1000));
+      if (!res.getHeader('Last-Modified')) res.setHeader('Last-Modified', stat.mtime.toUTCString());
       if (!res.getHeader('ETag')) res.setHeader('ETag', utils.etag(stat));
 
       // conditional GET support


### PR DESCRIPTION
I would be able to force Cache-Control and last-Modified in order to avoid browsers cache files or if I want to drive the cache without touch files on filesystem.
