### PR TITLE
Allowing maxAge to be set based on the request being made instead of just a static value.

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -37,7 +37,8 @@ var fs = require('fs')
  *
  * Options:
  *
- *    - `maxAge`   Browser cache maxAge in milliseconds. defaults to 0
+ *    - `maxAge`   Browser cache maxAge in milliseconds. defaults to 0. A function(path, type, request) may be passed,
+ *                 which can be used to specify the maxAge in milliseconds based on the request being made.
  *    - `hidden`   Allow transfer of hidden files. defaults to false
  *
  * @param {String} root
@@ -181,6 +182,11 @@ var send = exports.send = function(req, res, next, options){
       }
     // stream the entire file
     } else {
+      //If maxAge is a function, call it to get the maxAge as a number
+      if(typeof maxAge === 'function'){
+          maxAge = maxAge(path, type, req);
+      }
+
       res.setHeader('Content-Length', stat.size);
       res.setHeader('Cache-Control', 'public, max-age=' + (maxAge / 1000));
       res.setHeader('Last-Modified', stat.mtime.toUTCString());


### PR DESCRIPTION
I noticed this is similar to another pull request in the queue. The end goal is similar: to allow external code to set the maxAge header based on the request being made. I don't really care whether you take this pull request or the other one.
