### PR TITLE
Allows upstream middleware to consume and manipulate message body and still use bodyParser.

### DIFF
--- a/lib/middleware/bodyParser.js
+++ b/lib/middleware/bodyParser.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - bodyParser
  * Copyright(c) 2010 Sencha Inc.
@@ -26,6 +25,21 @@ function mime(req) {
   return str.split(';')[0];
 }
 
+/**                                                                                                                                                                                                            
+ * Run the parser over the raw body                                                                                                                                                                            
+ *                                                                                                                                                                                                             
+ * @return {Function}                                                                                                                                                                                          
+ * @api private                                                                                                                                                                                                
+ */
+
+function performParse(parser,req,next) {
+  try {
+    req.body = req.rawBody ? parser(req.rawBody) : {};
+  } catch (err) {
+    return next(err);
+  }
+  next();
+}
 /**
  * Parse request bodies.
  *
@@ -59,19 +73,17 @@ exports = module.exports = function bodyParser(){
     if ('GET' == req.method || 'HEAD' == req.method) return next();
     var parser = exports.parse[mime(req)];
     if (parser && !req.body) {
-      var data = '';
-      req.setEncoding('utf8');
-      req.on('data', function(chunk) { data += chunk; });
-      req.on('end', function(){
-        try {
-          req.body = data
-            ? parser(data)
-            : {};
-        } catch (err) {
-          return next(err);
-        }
-        next();
-      });
+      var data = req.rawBody || '';
+      if(data) {
+        performParse(parser,req,next);
+      } else {
+        req.setEncoding('utf8');
+        req.on('data', function(chunk) { data += chunk; });
+        req.on('end', function(){
+          req.rawBody = data;
+          performParse(parser,req,next);
+        });
+      }
     } else {
       next();
     }


### PR DESCRIPTION
Currently, if an upstream middleware consumes http(s).ServerRequest's message body events and valid json/form header are set then bodyParser will never complete it's attempt at getting the message body. This update allows earlier middleware to set req.rawBody, which will be used instead, avoiding the hang and allowing consumption and manipulation of the message body prior to parsing by bodyParser.

I noticed that as of the 10th, rawBody was removed. If desired, rawBody could be unset by bodyParser after parsing. 
