### PR TITLE
Change talked about in #354

### DIFF
--- a/lib/middleware/bodyParser.js
+++ b/lib/middleware/bodyParser.js
@@ -56,9 +56,12 @@ function mime(req) {
 
 exports = module.exports = function bodyParser(){
   return function bodyParser(req, res, next) {
+    if (req.body) return next();
+    req.body = {};
+
     if ('GET' == req.method || 'HEAD' == req.method) return next();
     var parser = exports.parse[mime(req)];
-    if (parser && !req.body) {
+    if (parser) {
       var data = '';
       req.setEncoding('utf8');
       req.on('data', function(chunk) { data += chunk; });

--- a/test/bodyParser.test.js
+++ b/test/bodyParser.test.js
@@ -46,13 +46,13 @@ module.exports = {
   'test POST with no data': function(){
     assert.response(app,
       { url: '/', method: 'POST' },
-      { body: '' });
+      { body: '{}' });
   },
 
   'test GET with content-type': function(){
     assert.response(app,
       { url: '/', headers: { 'Content-Type': 'application/json' }},
-      { body: '' });
+      { body: '{}' });
   },
   
   'test custom parser': function(){


### PR DESCRIPTION
Preforms check to see if req.body is already populated. If so, move on to the next middleware. If req.body isn't set the set it and attempt to parse the message body as usual.
