### PR TITLE
Check if request uses GET method before attempting to generate a csrf token

### DIFF
--- a/lib/middleware/csrf.js
+++ b/lib/middleware/csrf.js
@@ -73,11 +73,11 @@ module.exports = function csrf(options) {
     , value = options.value || defaultValue;
 
   return function(req, res, next){
-    // generate CSRF token
-    var token = req.session._csrf || (req.session._csrf = utils.uid(24));
-
     // ignore GET (for now)
     if ('GET' == req.method) return next();
+
+    // generate CSRF token
+    var token = req.session._csrf || (req.session._csrf = utils.uid(24));
 
     // determine value
     var val = value(req);


### PR DESCRIPTION
I was getting the following error on just about every request I made:

```
TypeError: Cannot read property '_csrf' of undefined
    at Object.handle (/home/eddie/dev/skatter.us/node_modules/express/node_modules/connect/lib/middleware/csrf.js:77:28)
    at next (/home/eddie/dev/skatter.us/node_modules/express/node_modules/connect/lib/http.js:201:15)
    at Object.session [as handle] (/home/eddie/dev/skatter.us/node_modules/express/node_modules/connect/lib/middleware/session.js:249:47)
    at next (/home/eddie/dev/skatter.us/node_modules/express/node_modules/connect/lib/http.js:201:15)
    at Object.cookieParser [as handle] (/home/eddie/dev/skatter.us/node_modules/express/node_modules/connect/lib/middleware/cookieParser.js:44:5)
    at next (/home/eddie/dev/skatter.us/node_modules/express/node_modules/connect/lib/http.js:201:15)
    at Object.bodyParser [as handle] (/home/eddie/dev/skatter.us/node_modules/express/node_modules/connect/lib/middleware/bodyParser.js:59:61)
    at next (/home/eddie/dev/skatter.us/node_modules/express/node_modules/connect/lib/http.js:201:15)
    at Object.handle (/home/eddie/dev/skatter.us/node_modules/stylus/lib/middleware.js:183:7)
    at next (/home/eddie/dev/skatter.us/node_modules/express/node_modules/connect/lib/http.js:201:15)
```
