### PR TITLE
headers, conditional range requests, tests

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -155,7 +155,27 @@ var send = exports.send = function(req, res, next, options){
       return;
     }
 
+    // header fields
+    if (!res.getHeader('Date')) res.setHeader('Date', new Date().toUTCString());
+    if (!res.getHeader('Cache-Control')) res.setHeader('Cache-Control', 'public, max-age=' + (maxAge / 1000));
+    if (!res.getHeader('Last-Modified')) res.setHeader('Last-Modified', stat.mtime.toUTCString());
+    if (!res.getHeader('ETag')) res.setHeader('ETag', utils.etag(stat));
+    if (!res.getHeader('content-type')) {
+      var charset = mime.charsets.lookup(type);
+      res.setHeader('Content-Type', type + (charset ? '; charset=' + charset : ''));
+    }
+    res.setHeader('Accept-Ranges', 'bytes');
+
+    // conditional GET support
+    if (utils.conditionalGET(req)) {
+      if (!utils.modified(req, res)) {
+        req.emit('static', null);
+        return utils.notModified(res);
+      }
+    }
+
     var opts = {};
+    var chunkSize = stat.size;
 
     // we have a Range request
     if (ranges) {
@@ -166,6 +186,7 @@ var send = exports.send = function(req, res, next, options){
         // TODO: multiple support
         opts.start = ranges[0].start;
         opts.end = ranges[0].end;
+        chunkSize = opts.end - opts.start + 1;
         res.statusCode = 206;
         res.setHeader('Content-Range', 'bytes '
           + opts.start
@@ -177,29 +198,9 @@ var send = exports.send = function(req, res, next, options){
       } else {
         return invalidRange(res);
       }
-    // stream the entire file
-    } else {
-      res.setHeader('Content-Length', stat.size);
-      if (!res.getHeader('Date')) res.setHeader('Date', new Date().toUTCString());
-      if (!res.getHeader('Cache-Control')) res.setHeader('Cache-Control', 'public, max-age=' + (maxAge / 1000));
-      if (!res.getHeader('Last-Modified')) res.setHeader('Last-Modified', stat.mtime.toUTCString());
-      if (!res.getHeader('ETag')) res.setHeader('ETag', utils.etag(stat));
-
-      // conditional GET support
-      if (utils.conditionalGET(req)) {
-        if (!utils.modified(req, res)) {
-          req.emit('static', null);
-          return utils.notModified(res);
-        }
-      }
     }
 
-    // header fields
-    if (!res.getHeader('content-type')) {
-      var charset = mime.charsets.lookup(type);
-      res.setHeader('Content-Type', type + (charset ? '; charset=' + charset : ''));
-    }
-    res.setHeader('Accept-Ranges', 'bytes');
+    res.setHeader('Content-Length', chunkSize);
 
     // transfer
     if (head) return res.end();

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -169,13 +169,31 @@ module.exports = {
   'test Range': function(){
     assert.response(app,
       { url: '/list', headers: { Range: 'bytes=0-4' }},
-      { body: '12345', status: 206 });
+      { body: '12345', 'Content-Range': 'bytes 0-4/9', status: 206 });
   },
   
   'test Range 2': function(){
     assert.response(app,
-      { url: '/list', headers: { Range: 'bytes=5-9' }},
-      { body: '6789', status: 206 });
+      { url: '/list', headers: { Range: 'bytes=5-8' }},
+      { body: '6789', 'Content-Range': 'bytes 5-8/9', status: 206 });
+  },
+  
+  'test Range 3': function(){     
+    assert.response(app,
+      { url: '/list', headers: { Range: 'bytes=3-6' }},
+      { body: '4567', 'Content-Range': 'bytes 3-6/9', status: 206 });
+  },
+  
+  'test conditional range': function(){
+    assert.response(app,
+      { url: '/list' },
+      function(res) {
+        res.headers.should.have.property('etag');
+        assert.response(app,
+          { url: '/list', headers: { Range: 'bytes=3-6', 'If-None-Match': res.headers.etag }},
+          { status: 304 }
+        );
+      });
   },
   
   'test invalid Range': function(){


### PR DESCRIPTION
Fixed a couple issue with important headers not being sent, may be going overboard now.
Date wasn't not being sent with range requests
Added Content-Length to range requests
Conditional requests with a range should return 304 if the conditions are false (RFC 2616 14.35.2)
Added a test for conditional ranges
Fixed what appeared to be a problems with some of the range tests
