### PR TITLE
Prevent multiple vhost responses

### DIFF
--- a/lib/middleware/vhost.js
+++ b/lib/middleware/vhost.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - vhost
  * Copyright(c) 2010 Sencha Inc.
@@ -36,7 +35,7 @@ module.exports = function vhost(hostname, server){
     var host = req.headers.host.split(':')[0];
     if (req.subdomains = regexp.exec(host)) {
       req.subdomains = req.subdomains[0].split('.').slice(0, -1);
-      server.emit('request', req, res, next);
+      server.emit('request', req, res);
     } else {
       next();
     }


### PR DESCRIPTION
Currently, vhost evaluates all matching subdomains and and executes ALL requests to vhost servers. This causes multiple responses to be served. Example:

```
connect(
  connect.vhost('static.foo.com', connect.createServer(...middleware...)),
  connect.vhost('*.foo.com', connect.createServer(...middleware...))
);
```

A call to `static.foo.com` causes both servers to be invoked. Is this by design? Is there any real-world use-case for this? It seems **much** more intuitive to call just the first server (ie. depend on ordering when multiple matching declarations are found).

If this change is rejected, the only other way how to accomplish the above is via unwieldy regexp like following, and that seems just wrong:

```
connect(
  connect.vhost('static.foo.com', connect.createServer(...middleware...)),
  connect.vhost('*(?<!static).foo.com', connect.createServer(...middleware...))
);
```
