### PR TITLE
make directory redirects optional

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -53,6 +53,11 @@ exports = module.exports = function static(root, options){
   if (!root) throw new Error('static() root path required');
   options.root = root;
 
+  // defaults
+  if (options["redirectDirectories"] == null) {
+    options["redirectDirectories"] = true;
+  }
+
   return function static(req, res, next) {
     options.path = req.url;
     options.getOnly = true;
@@ -134,9 +139,13 @@ var send = exports.send = function(req, res, next, options){
         : next(err);
     // redirect directory in case index.html is present
     } else if (stat.isDirectory()) {
-      res.statusCode = 301;
-      res.setHeader('Location', url.pathname + '/');
-      res.end('Redirecting to ' + url.pathname + '/');
+      if (options.redirectDirectories) {
+        res.statusCode = 301;
+        res.setHeader('Location', url.pathname + '/');
+        res.end('Redirecting to ' + url.pathname + '/');
+      } else {
+        next()
+      }
       return;
     }
 


### PR DESCRIPTION
optionally stop redirecting directories to new path, allows node to dynamically render paths which are directories.

current behavior is matched.
/images redirects to /images/

with passed in parameter
/images called next() which lets node render a page
