### PR TITLE
Correctly insert "index.html" for url paths ending in "/" on Windows

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - staticProvider
  * Copyright(c) 2010 Sencha Inc.
@@ -109,7 +108,10 @@ var send = exports.send = function(req, res, next, options){
 
   // when root is not given, consider .. malicious
   if (!root && ~path.indexOf('..')) return next(403);
-
+  
+  // index.html support
+  if ('/' == path[path.length - 1]) path += 'index.html';
+  
   // join / normalize from optional root dir
   path = normalize(join(root, path));
 
@@ -117,9 +119,6 @@ var send = exports.send = function(req, res, next, options){
   if (root && 0 != path.indexOf(root)) return fn
     ? fn(new Error('Forbidden'))
     : next(403);
-
-  // index.html support
-  if ('/' == path[path.length - 1]) path += 'index.html';
 
   // "hidden" file
   if (!hidden && '.' == basename(path)[0]) return next();


### PR DESCRIPTION
Since 'normalize' changes all the forward slashes to backward slashes on Windows, we need to check in the path ends in "/" BEFORE we call 'normalize'.
