### PR TITLE
Remove req._logging at the end of logger() function so you could use two 

### DIFF
--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - logger
  * Copyright(c) 2010 Sencha Inc.
@@ -150,7 +149,9 @@ exports = module.exports = function logger(options) {
         stream.write(line + '\n', 'ascii');
       };
     }
-
+    
+    // Clean up so we can use connect.logger() twice to log to different places
+    req._logging = false;
 
     next();
   };


### PR DESCRIPTION
Remove req._logging at the end of logger() function so you could use two logger helpers, for example one to log to stdout and one to a file.
