### PR TITLE
Unifies multipart, json, and form-urlencoded in the bodyParser() middleware

### DIFF
--- a/lib/middleware/bodyParser.js
+++ b/lib/middleware/bodyParser.js
@@ -109,7 +109,6 @@ exports.parse['application/x-www-form-urlencoded'] = function(req, options, fn){
 /**
  * Parse application/json.
  */
-
 exports.parse['application/json'] = function(req, options, fn){
   var buf = '';
   req.setEncoding('utf8');
@@ -126,35 +125,32 @@ exports.parse['application/json'] = function(req, options, fn){
 
 /**
  * Parse multipart/form-data.
- * 
+ *
  * TODO: make multiple support optional
  * TODO: revisit "error" flag if it's a formidable bug
- * TODO: support nesting { user: { images: [...] }}
  */
-
 exports.parse['multipart/form-data'] = function(req, options, fn){
   var form = new formidable.IncomingForm
-    , query = []
-    , files = {}
+    , data = {}
     , done;
 
   Object.keys(options).forEach(function(key){
     form[key] = options[key];
   });
 
-  form.on('field', function(name, val){
-    query.push(name + '=' + val);
-  });
-
-  form.on('file', function(name, file){
-    if (Array.isArray(files[name])) {
-      files[name].push(file);
-    } else if (files[name]) {
-      files[name] = [files[name], file];
+  function collect(name, val){
+    if (Array.isArray(data[name])) {
+      data[name].push(val);
+    } else if (data[name]) {
+      data[name] = [data[name], val];
     } else {
-      files[name] = file;
+      data[name] = val;
     }
-  });
+  }
+
+  form.on('field', collect);
+
+  form.on('file', collect);
 
   form.on('error', function(err){
     fn(err);
@@ -164,12 +160,7 @@ exports.parse['multipart/form-data'] = function(req, options, fn){
   form.on('end', function(){
     if (done) return;
     try {
-      query = query.join('&');
-      query = qs.parse(query);
-      req.body = query;
-      Object.keys(files).forEach(function(name){
-        req.body[name] = files[name];
-      });
+      req.body = qs.parse(data); // using the same nest-name mapping logic
       fn();
     } catch (err) {
       fn(err);
@@ -178,3 +169,4 @@ exports.parse['multipart/form-data'] = function(req, options, fn){
 
   form.parse(req);
 };
+


### PR DESCRIPTION
TJ just merge the `qs` fork (v0.4.0) to enable parse could accept an object as param.

So, it's right time to change bodyParser to use the qs.parse directly.

test passed.
