### PR TITLE
process.memoryUsage().vsize was removed in node v0.5.10

### DIFF
--- a/lib/middleware/profiler.js
+++ b/lib/middleware/profiler.js
@@ -63,7 +63,6 @@ function compare(req, start, end) {
   row(req.method, req.url);
   row('response time:', (end.time - start.time) + 'ms');
   row('memory rss:', formatBytes(end.mem.rss - start.mem.rss));
-  row('memory vsize:', formatBytes(end.mem.vsize - start.mem.vsize));
   row('heap before:', formatBytes(start.mem.heapUsed) + ' / ' + formatBytes(start.mem.heapTotal));
   row('heap after:', formatBytes(end.mem.heapUsed) + ' / ' + formatBytes(end.mem.heapTotal));
   console.log();


### PR DESCRIPTION
This is why connect.profiler will print something like

```
 memory vsize: NaNgb
```

[Source](http://blog.nodejs.org/2011/10/21/node-v0-5-10/)
