### PR TITLE
log 304 for staticCache

### DIFF
--- a/lib/middleware/staticCache.js
+++ b/lib/middleware/staticCache.js
@@ -127,6 +127,8 @@ module.exports = function staticCache(options){
         if (!utils.modified(req, res, header)) {
           header['content-length'] = 0;
           res.writeHead(304, header);
+          // log 304 in logger, not 200
+          res.statusCode = 304;          
           return res.end();
         }
       }


### PR DESCRIPTION
#### problem

when the conditional get of staticCache middleware succeed, 
it logs 200 instead.
#### solution

I added one line:
res.statusCode = 304
#### still confused

Do you know any difference between 
res.writeHead(304, header)  and 
res.statusCode = 304

----- appreciate your feedback
