### PR TITLE
Adding windows support to server the index.html in the static.js

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -129,7 +129,8 @@ var send = exports.send = function(req, res, next, options){
     : utils.forbidden(res);
 
   // index.html support
-  if ('/' == path[path.length - 1]) path += 'index.html';
+  // adding windows suppot to the path
+  if ('/' == path[path.length - 1] || '\\' == path[path.length - 1]) path += 'index.html';
 
   // "hidden" file
   if (!hidden && '.' == basename(path)[0]) return next();


### PR DESCRIPTION
server root in windows is '\' and when it is represented in javascript it becomes '\'.
may be this is an issue with the path, but this solves the problem on two windows machines that i tested
