### PR TITLE
Bug(?) in use of res._headerSent vs res._header in calling _implicitHeaders

### DIFF
--- a/lib/middleware/compress.js
+++ b/lib/middleware/compress.js
@@ -66,8 +66,8 @@ module.exports = function compress(options) {
 
   return function(req, res, next){
     var accept = req.headers['accept-encoding']
-      , write = res.write
-      , end = res.end
+      , orig_write = res.write
+      , orig_end = res.end
       , stream
       , method;
 
@@ -77,35 +77,33 @@ module.exports = function compress(options) {
     // proxy
 
     res.write = function(chunk, encoding){
-      if (!this.headerSent) this._implicitHeader();
-      return stream.write(chunk, encoding);
+      if (!this._header) {
+        this._implicitHeader();
+      }
+      if (stream)
+        return stream.write(chunk, encoding);
+      else
+        return orig_write.call(res, chunk, encoding);
     };
 
     res.end = function(chunk, encoding){
-      if (!this.headerSent) this._implicitHeader();
       if (chunk) this.write(chunk, encoding);
-      return stream.end();
+      if (stream)
+        return stream.end();
+      else
+        return orig_end.call(res);
     };
 
-    function revert() {
-      stream = res;
-      res.write = write;
-      res.end = end;
-    }
-
-    // head
-    if ('HEAD' == req.method) revert();
-
     res.on('header', function(){
+      // Do we want a compressed stream?
       // default request filter
-      if (!filter(req, res)) return revert();
-
+      if (!filter(req, res)) return;
       // SHOULD use identity
-      if (!accept) return revert();
-
+      if (!accept) return;
+      // head
+      if ('HEAD' == req.method) return;
       // default to gzip
       if ('*' == accept.trim()) method = 'gzip';
-
       // compression method
       if (!method) {
         for (var i = 0, len = names.length; i < len; ++i) {
@@ -115,10 +113,10 @@ module.exports = function compress(options) {
           }
         }
       }
-
       // compression method
-      if (!method) return revert();
+      if (!method) return;
 
+      // Yes, we want a compressed stream.
       // compression stream
       stream = exports.methods[method](options);
 
@@ -129,12 +127,14 @@ module.exports = function compress(options) {
       // compression
 
       stream.on('data', function(chunk){
-        write.call(res, chunk);
+        orig_write.call(res, chunk);
       });
 
       stream.on('end', function(){
-        end.call(res);
+        orig_end.call(res);
       });
+
+      
     });
 
     next();

--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -227,7 +227,6 @@ function session(options){
     res.end = function(data, encoding){
       res.end = end;
       if (!req.session) return res.end(data, encoding);
-      if (!res.headerSent) res._implicitHeader();
       req.session.resetMaxAge();
       req.session.save(function(){
         res.end(data, encoding);

--- a/lib/patch.js
+++ b/lib/patch.js
@@ -22,6 +22,8 @@ if (res._hasConnectPatch) return;
 /**
  * Provide a public "header sent" flag
  * until node does.
+ * NOTE: !res.headerSent does not imply
+ *   that headers are further editable.
  *
  * @return {Boolean}
  * @api public


### PR DESCRIPTION
I was using 2.0.0alpha in master when the session middleware started crapping out. (see below)

This is caused by recent changes in middleware/session.js that checked res.headerSent (which checks res._headerSent), which is not the same as res._header.

> > I think _headerSent means whether the header was sent in the pipe, while _header means the _header was calculated and stored.

Upon further investigation I found that the _implicitHeaders() call in middleware/session.js is unnecessary, as node.js res.end() will call _implicitHeaders as necessary.

Along the way I also refactored compress.js. I removed revert(), which was confusing and seemed potentially dangerous in a middleware layer since other layers may depend on res.write/res.end being immutable. I reorganized some lines too.

Please review. Thanks for reading!

Error: Can't render headers after they are sent to the client.
    at ServerResponse.<anonymous> (http.js:573:11)
    at ServerResponse._renderHeaders (/Users/jae/workspace/src/harmonic/node_modules/connect/lib/patch.js:69:25)
    at ServerResponse.<anonymous> (http.js:840:20)
    at ServerResponse.writeHead (/Users/jae/workspace/src/harmonic/node_modules/connect/lib/patch.js:75:20)
    at ServerResponse._implicitHeader (http.js:797:8)
    at ServerResponse.<anonymous> (/Users/jae/workspace/src/harmonic/node_modules/connect/lib/middleware/session.js:231:32)
    at ServerResponse.reply (/Users/jae/workspace/src/harmonic/lib/harmonic/router.coffee:40:21)
    at ServerResponse.renderLayout (/Users/jae/workspace/src/harmonic/lib/harmonic/router.coffee:96:22)
    at Route.fn (/Users/jae/workspace/src/harmonic/apps/default/index.coffee:14:24)
    at /Users/jae/workspace/src/harmonic/lib/harmonic/router.coffee:78:16
