### PR TITLE
When route is not '/', req.url that is not trailing '/' causes incorrect response.

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - HTTPServer
  * Copyright(c) 2010 Sencha Inc.
@@ -155,6 +154,15 @@ app.handle = function(req, res, out) {
 
       c = path[layer.route.length];
       if (c && '/' != c && '.' != c) return next(err);
+
+      // In case of req.url is not trailing '/' but is directory,
+      // Must be redirect to directory followed by '/', instead of adding '/index.html'.
+      if (path == layer.route) {
+        res.statusCode = 301;
+        res.setHeader('Location', layer.route + '/');
+        res.end('Redirecting to ' + layer.route + '/');
+        return;
+      }
 
       // Call the layer handler
       // Trim off the part of the url that matches the route


### PR DESCRIPTION
server = connect.createServer();
server.use('/any-path', connect.static(__dirname + '/public'));

When req.url is 'http://any-domain/any-path',
static middleware will response with 'http://any-domain/any-path/index.html'.

But the request of web browser is '/any-path', not '/any-path/'. the browser mis-guesses the path of request is '/', not '/any-path/'.
