### PR TITLE
master: utils.unsign does not extract the sign correctly if the value contains a period

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -176,8 +176,7 @@ exports.sign = function(val, secret){
  */
 
 exports.unsign = function(val, secret){
-  var parts = val.split('.')
-    , str = parts[0]
+  var str = val.slice(0,val.lastIndexOf('.'));
   return exports.sign(str, secret) == val
     ? str
     : false;

--- a/test/utils.js
+++ b/test/utils.js
@@ -73,6 +73,13 @@ describe('utils.[un]sign()', function(){
     val = utils.unsign('something.KnUAgnazIiUClhgLhvg91JfTBAo', 'foo');
     val.should.equal('something');
 
+    // make sure cookie values with periods don't trump the signature
+    val = utils.sign('something.for.nothing', 'foo');
+    val.should.equal('something.for.nothing.jcLcIVMfGbh9EDXw7EiTqh/CWMo');
+
+    val = utils.unsign('something.for.nothing.jcLcIVMfGbh9EDXw7EiTqh/CWMo', 'foo');
+    val.should.equal('something.for.nothing');
+
     // invalid secret
     val = utils.unsign('something.KnUAgnazIiUClhgLhvg91JfTBAo', 'something');
     val.should.be.false;


### PR DESCRIPTION
Using signed cookie sessions that happen to store a users email address and the cookie value on next request would be reset because the sign would fail, as unsign calls val.split('.') and only uses the first returning array item.

To fix, I considered re-joining on length > 2 or a regex, but thought a slice with lastIndexOf would ultimately be faster, although I'm new to hard core js hacking and don't have a fast way to bench this and prove my assumption, so hopefully I'm making an ass of nobody ;)  

Tests included
