### PR TITLE
The utils.uid is used as a nonce; it should be secure.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -137,15 +137,9 @@ exports.escape = function(html){
  */
 
 exports.uid = function(len) {
-  var buf = []
-    , chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-    , charlen = chars.length;
-
-  for (var i = 0; i < len; ++i) {
-    buf.push(chars[Math.random() * charlen | 0]);
-  }
-
-  return buf.join('');
+  return crypto.randomBytes(Math.ceil((len*3)/4))
+    .toString('base64')
+    .slice(0, len);
 };
 
 /**


### PR DESCRIPTION
```
% grep -r uid lib
lib/middleware/csrf.js:    var token = req.session._csrf || (req.session._csrf = utils.uid(24));
lib/middleware/session.js:    req.sessionID = utils.uid(24);
```
