### PR TITLE
The static middleware has a bug in its computation of Content-Length header when HTTP request has "range" header and range's end is greater than the size of the response.

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -168,7 +168,7 @@ var send = exports.send = function(req, res, next, options){
         // TODO: multiple support
         opts.start = ranges[0].start;
         opts.end = ranges[0].end;
-        len = opts.end - opts.start + 1;
+        len = Math.min(len, opts.end - opts.start + 1);
         res.statusCode = 206;
         res.setHeader('Content-Range', 'bytes '
           + opts.start


### PR DESCRIPTION
... have range header
