### PR TITLE
Ignore HEAD requests when performing CSRF token checks [closes #409].

### DIFF
--- a/lib/middleware/csrf.js
+++ b/lib/middleware/csrf.js
@@ -76,7 +76,7 @@ module.exports = function csrf(options) {
     // generate CSRF token
     var token = req.session._csrf || (req.session._csrf = utils.uid(24));
 
-    // ignore GET (for now)
+    // ignore GET & HEAD (for now)
     if ('GET' == req.method || 'HEAD' == req.method) return next();
 
     // determine value


### PR DESCRIPTION
Tiny fix so CSRF middleware doesn't reject HEAD requests.
