### PR TITLE
Change session behavior

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -66,7 +66,7 @@ var warning = 'Warning: connection.session() MemoryStore is not\n'
  *
  *   - `key` cookie name defaulting to `connect.sid`
  *   - `store` session store instance
- *   - `cookie` session cookie settings, defaulting to `{ path: '/', httpOnly: true, maxAge: 14400000 }`
+ *   - `cookie` session cookie settings, defaulting to `{ path: '/', httpOnly: true, maxAge: undefined }`
  *   - `proxy` trust the reverse proxy when setting secure cookies (via "x-forwarded-proto")
  *
  * ## req.session
@@ -221,7 +221,7 @@ function session(options){
         , secured = cookie.secure && tls;
 
       debug('secured: %s', !!secured);
-      if (secured || !cookie.secure) {
+      if ((secured || !cookie.secure) && (!req.cookies[key] || req.cookies[key] != req.sessionID)) {
         debug('set %s to %s', key, req.sessionID);
         res.setHeader('Set-Cookie', cookie.serialize(key, req.sessionID));
       }
@@ -233,7 +233,6 @@ function session(options){
       res.end = end;
       if (!req.session) return res.end(data, encoding);
       debug('saving');
-      req.session.resetMaxAge();
       req.session.save(function(){
         debug('saved');
         res.end(data, encoding);

--- a/lib/middleware/session/cookie.js
+++ b/lib/middleware/session/cookie.js
@@ -23,7 +23,7 @@ var utils = require('../../utils');
 var Cookie = module.exports = function Cookie(req, options) {
   this.path = '/';
   this.httpOnly = true;
-  this.maxAge = 14400000;
+  this.maxAge = undefined;
   if (options) utils.merge(this, options);
   Object.defineProperty(this, 'req', { value: req });
   this.originalMaxAge = undefined == this.originalMaxAge
@@ -68,9 +68,11 @@ Cookie.prototype = {
    */
   
   set maxAge(ms) {
-    this.expires = 'number' == typeof ms
-      ? new Date(Date.now() + ms)
-      : ms;
+    this.expires = !ms
+      ? undefined
+      : ('number' == typeof ms
+        ? new Date(Date.now() + ms)
+        : ms);
   },
 
   /**
@@ -81,9 +83,11 @@ Cookie.prototype = {
    */
 
   get maxAge() {
-    return this.expires instanceof Date
-      ? this.expires.valueOf() - Date.now()
-      : this.expires;
+    return !this.expires
+      ? undefined
+      : (this.expires instanceof Date
+        ? this.expires.valueOf() - Date.now()
+        : this.expires);
   },
 
   /**


### PR DESCRIPTION
1. I add support undefined state for maxAge cookie param and set it by default. undefined value for this param means that session will live while browser session live and die together too. Before this time it was impossible (0 or undefined values for maxAge created zero-time session). Also 4, 5, 10 hours for default session live time - wrong way i think, because it application dependent param. Browser session live time looks better for default value.
2. Before this time session cookie cookies sent with each response. This behavior is prevented caching pages with frontend web-servers like nginx because we must always accept new cookies. Now the cookies sent only once - after creation of session and not prolongate his lifetime until session ends.

Sorry for my bad english, but i hope that you will understand me. Thanks.
