### PR TITLE
Bugfix for serving .svgz (gzipped Scalable Vector Graphics) via connect....

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -14,6 +14,7 @@ var fs = require('fs')
   , join = path.join
   , basename = path.basename
   , normalize = path.normalize
+  , extname = path.extname
   , utils = require('../utils')
   , Buffer = require('buffer').Buffer
   , parse = require('url').parse
@@ -152,6 +153,14 @@ var send = exports.send = function(req, res, next, options){
       res.setHeader('Content-Type', type + (charset ? '; charset=' + charset : ''));
     }
     res.setHeader('Accept-Ranges', 'bytes');
+    
+    // Add mandatory gzip header for svgz files
+    if (type == 'image/svg+xml') {
+    	if (extname(path) == '.svgz') {
+	  		res.setHeader('Content-Encoding', 'gzip');
+		  }
+	  }
+
 
     // conditional GET support
     if (utils.conditionalGET(req)) {


### PR DESCRIPTION
...static. Browsers with Webkit and Gecko rendering engines rely on the "Content-Encoding: gzip" HTTP header in order to properly recognize .svgz files.

This fixes a very annoying "feature" of at least Firefox and Chromium on Linux and Mac, as .SVGZ files are not recognized by the browser as gzipped .SVG files when served without the "Content-Encoding: gzip" HTTP header. As I'd love to serve scalable graphics to my users in a minified version - hence the svgz - this bugged us while serving content from static directories with node.js.
