### PR TITLE
Report the original url in the 'Cannot...' message when no route matches

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -142,7 +142,7 @@ app.handle = function(req, res, out) {
         res.statusCode = 404;
         res.setHeader('Content-Type', 'text/plain');
         if ('HEAD' == req.method) return res.end();
-        res.end('Cannot ' + req.method + ' ' + utils.escape(req.url));
+        res.end('Cannot ' + req.method + ' ' + utils.escape(req.originalUrl));
       }
       return;
     }


### PR DESCRIPTION
When some middleware rewrites req.url, the rewritten url is used in the 'Cannot...' message emitted by connect if it turns out that no route matches. That's a bit confusing.

Example: If a client requests `/foo/bar/quux/` from the below server, the error message will say `Cannot GET /bar/quux/`:

```
var app = require('connect')()
    .use(function removeFirstFragment(req, res, next) {
        req.url = req.url.replace(/^\/[^\/]+/, '');
        next();
    });
require('http').createServer(app).listen(4000);
```
