### PR TITLE
Middleware static - Properly merge options, allow getOnly to be configured.

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -46,16 +46,20 @@ var fs = require('fs')
  * @api public
  */
 
+
+
+
 exports = module.exports = function static(root, options){
-  options = options || {};
+  options = utils.merge({
+    getOnly : true,
+    root : root
+  }, options);
 
   // root required
-  if (!root) throw new Error('static() root path required');
-  options.root = root;
+  if (!options.root) throw new Error('static() root path required');
 
   return function static(req, res, next) {
     options.path = req.url;
-    options.getOnly = true;
     send(req, res, next, options);
   };
 };


### PR DESCRIPTION
Pretty small change, but I needed getOnly to be false on a recent project, and found that it was hard coded to `true`. Fixed up options merging and made getOnly configurable.
