### PR TITLE
content-range fix when requested range > file size

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -198,7 +198,7 @@ var send = exports.send = function(req, res, next, options){
         res.setHeader('Content-Range', 'bytes '
           + opts.start
           + '-'
-          + opts.end
+          + Math.min(opts.end, stat.size-1)
           + '/'
           + stat.size);
       // invalid range


### PR DESCRIPTION
Right now, static.js generates a Content-Range header which is incorrect if the incoming last-byte-position is greater than the total length of the file. According to RFC2616, a byte-content-range-spec with a byte-range-resp-spec whose last- byte-pos value is less than its first-byte-pos value, or whose instance-length value is less than or equal to its last-byte-pos value, is invalid.
(noticed this since Content-Length (which was apparently already fixed some time ago) was still wrong in my version installed from npm and that caused me some troubles)
