### PR TITLE
made the methods skipped in the json/multipart/urlencoded middlewares optional

### DIFF
--- a/lib/middleware/json.js
+++ b/lib/middleware/json.js
@@ -25,12 +25,23 @@ var utils = require('../utils');
 
 exports = module.exports = function(options){
   options = options || {};
+
+  if (typeof options.skip_methods === "undefined") {
+    options.skip_methods = ["GET", "HEAD"];
+  }
+
   return function json(req, res, next) {
     if (req._body) return next();
     req.body = req.body || {};
 
-    // ignore GET
-    if ('GET' == req.method || 'HEAD' == req.method) return next();
+    // ignore appropriate methods
+    if (options.skip_methods) {
+      for (var i in options.skip_methods) {
+        if (options.skip_methods[i] == req.method) {
+          return next();
+        }
+      }
+    }
 
     // check Content-Type
     if ('application/json' != utils.mime(req)) return next();

--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -36,13 +36,24 @@ var formidable = require('formidable')
 
 exports = module.exports = function(options){
   options = options || {};
+
+  if (typeof options.skip_methods === "undefined") {
+    options.skip_methods = ["GET", "HEAD"];
+  }
+
   return function multipart(req, res, next) {
     if (req._body) return next();
     req.body = req.body || {};
     req.files = req.files || {};
 
-    // ignore GET
-    if ('GET' == req.method || 'HEAD' == req.method) return next();
+    // ignore appropriate methods
+    if (options.skip_methods) {
+      for (var i in options.skip_methods) {
+        if (options.skip_methods[i] == req.method) {
+          return next();
+        }
+      }
+    }
 
     // check Content-Type
     if ('multipart/form-data' != utils.mime(req)) return next();

--- a/lib/middleware/urlencoded.js
+++ b/lib/middleware/urlencoded.js
@@ -26,12 +26,23 @@ var utils = require('../utils')
 
 exports = module.exports = function(options){
   options = options || {};
+
+  if (typeof options.skip_methods === "undefined") {
+    options.skip_methods = ["GET", "HEAD"];
+  }
+
   return function urlencoded(req, res, next) {
     if (req._body) return next();
     req.body = req.body || {};
 
-    // ignore GET
-    if ('GET' == req.method || 'HEAD' == req.method) return next();
+    // ignore appropriate methods
+    if (options.skip_methods) {
+      for (var i in options.skip_methods) {
+        if (options.skip_methods[i] == req.method) {
+          return next();
+        }
+      }
+    }
 
     // check Content-Type
     if ('application/x-www-form-urlencoded' != utils.mime(req)) return next();


### PR DESCRIPTION
Added a new options parameter for each; `skip_methods'. it, by default, is set
to ["GET", "HEAD"]. This is in line with the previous behaviour. All existing
tests have been confirmed to pass still. As far as I can see, there are no BC
breaks.
