### PR TITLE
staticCache: don't cache responses containing a content-range / partial content

### DIFF
--- a/lib/middleware/staticCache.js
+++ b/lib/middleware/staticCache.js
@@ -81,6 +81,9 @@ module.exports = function staticCache(options){
       // ignore larger files
       if (!contentLength || contentLength > maxlen) return;
 
+      //don't cache partial files
+      if (headers['content-range']) return;
+
       // dont cache items we shouldn't be
       // TODO: real support for must-revalidate / no-cache
       if ( cc['no-cache']


### PR DESCRIPTION
There is a possible problem with staticCache in case partial content is transferred. If a content-range with content-length < 256k is transferred, it would be cached. If one of the next requests is a simple GET of the same resource without a range, then it will hit the cache (range requests are safe since https://github.com/senchalabs/connect/issues/387 ), resulting in a 200 response (=OK) with the content-range and -length of the cached data instead of the entire file (=not OK), which means corrupt downloads.
This can quite easily occur when someone serves an HTML 5 video from static (both types of requests are used, and small ranges too (near beginning and end)), depending on the connected client(s).

As a quick fix (saw there was more stuff in the issue list) I suggest not to cache anything containing a content-range
