### PR TITLE
Remove JSON validity restriction

### DIFF
--- a/lib/middleware/json.js
+++ b/lib/middleware/json.js
@@ -43,7 +43,6 @@ exports = module.exports = function(options){
     req.setEncoding('utf8');
     req.on('data', function(chunk){ buf += chunk });
     req.on('end', function(){
-      if ('{' != buf[0] && '[' != buf[0]) return next(utils.error(400));
       try {
         req.body = JSON.parse(buf);
         next();


### PR DESCRIPTION
According to json.org, valid JSON can start with any of the following:
- double-quote- for strings
- left bracket- for arrays
- left brace- for objects
- true/false- for booleans
- number- for numbers
- null- for null

I ran into a problem where I was getting 400 errors when POSTing properly quoted strings, and found this to be the cause. The only reason I can think of for this restriction is speed (try/catch is expensive). If this is not an acceptable solution, I have another pull request with a regex to replace this conditional.
