### PR TITLE
Replace overly restrictive JSON check for regex that covers all cases

### DIFF
--- a/lib/middleware/json.js
+++ b/lib/middleware/json.js
@@ -43,7 +43,7 @@ exports = module.exports = function(options){
     req.setEncoding('utf8');
     req.on('data', function(chunk){ buf += chunk });
     req.on('end', function(){
-      if ('{' != buf[0] && '[' != buf[0]) return next(utils.error(400));
+      if (!/^\s*(?:[{["]|true|false|null|\d)/.test(buf)) return next(utils.error(400));
       try {
         req.body = JSON.parse(buf);
         next();


### PR DESCRIPTION
I prefer my other pull request for the same problem, but this regex should cover all cases if performance was the reason for the overly restrictive JSON check.

As mentioned in the other pull request, I need to POST quoted strings, like `"hello world"`, which is valid JSON.
