### PR TITLE
`createServer()` should accept middleware.

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -61,7 +61,10 @@ function createServer() {
   utils.merge(app, proto);
   utils.merge(app, EventEmitter.prototype);
   app.route = '/';
-  app.stack = [].slice.apply(arguments);
+  app.stack = [];
+  [].forEach.call(arguments, function(fn) {
+    app.use(fn);
+  });
   return app;
 };
 

--- a/test/mounting.js
+++ b/test/mounting.js
@@ -2,6 +2,18 @@
 var connect = require('../')
   , http = require('http');
 
+describe('createServer()', function(){
+  it('should accept middleware', function(done){
+    var app = connect(function(req, res, next) {
+      res.end('blog');
+    });
+
+    app.request()
+    .get('/')
+    .expect('blog', done);
+  });
+});
+
 describe('app.use()', function(){
   var app;
 


### PR DESCRIPTION
`createServer` used to accept middleware, to be mounted at `/`. In fact, a lot of the included examples try to use this functionality, but are right now broken.
