### PR TITLE
Fix bug in compress detecting content-type set via writeHead

### DIFF
--- a/lib/patch.js
+++ b/lib/patch.js
@@ -69,10 +69,26 @@ if (!res._hasConnectPatch) {
     return _renderHeaders.call(this);
   };
 
-  res.writeHead = function(){
+  res.writeHead = function(statusCode){
+    var reasonPhrase, headers, headerIndex;
+
+    if (typeof arguments[1] == 'string') {
+      reasonPhrase = arguments[1];
+      headerIndex = 2;
+    } else {
+      headerIndex = 1;
+    }
+    headers = arguments[headerIndex];
+
+    if (headers) {
+      for (var name in headers) {
+        this.setHeader(name, headers[name]);
+      }
+    }
+
     if (!this._emittedHeader) this.emit('header');
     this._emittedHeader = true;
-    return writeHead.apply(this, arguments);
+    return writeHead.call(this, statusCode, reasonPhrase);
   };
 
   res._hasConnectPatch = true;

--- a/test/compress.js
+++ b/test/compress.js
@@ -7,10 +7,72 @@ var app = connect();
 app.use(connect.compress());
 app.use(connect.static(fixtures));
 
+var dynamicApp = connect();
+dynamicApp.use(connect.compress());
+
+dynamicApp.use(function(req, res){
+  var body = '- groceries';
+
+  if (req.url == '/setHeaderEnd') {
+    res.setHeader('Content-Type', 'text/plain')
+    res.end(body);
+    return
+  }
+
+  if (req.url == '/writeHeadEnd') {
+    res.writeHead(200, {
+      'Content-Length': body.length,
+      'Content-Type': 'text/plain'
+    });
+    res.end(body);
+    return
+  }
+
+  if (req.url == '/writeHeadWriteEnd') {
+    res.writeHead(200, {
+      'Content-Length': body.length,
+      'Content-Type': 'text/plain'
+    });
+    res.write(body)
+    res.end();
+    return
+  }
+});
+
 describe('connect.compress()', function(){
   it('should gzip files', function(done){
     app.request()
     .get('/todo.txt')
+    .set('Accept-Encoding', 'gzip')
+    .end(function(res){
+      res.body.should.not.equal('- groceries');
+      done();
+    });
+  })
+
+  it('should gzip after setHeader(), end()', function(done){
+    dynamicApp.request()
+    .get('/setHeaderEnd')
+    .set('Accept-Encoding', 'gzip')
+    .end(function(res){
+      res.body.should.not.equal('- groceries');
+      done();
+    });
+  })
+
+  it('should gzip after writeHead(), end()', function(done){
+    dynamicApp.request()
+    .get('/writeHeadEnd')
+    .set('Accept-Encoding', 'gzip')
+    .end(function(res){
+      res.body.should.not.equal('- groceries');
+      done();
+    });
+  })
+
+  it('should gzip after writeHead(), write(), end()', function(done){
+    dynamicApp.request()
+    .get('/writeHeadWriteEnd')
     .set('Accept-Encoding', 'gzip')
     .end(function(res){
       res.body.should.not.equal('- groceries');


### PR DESCRIPTION
The compress middleware (and presumably other middleware that respond to the 'header' event) did not properly detect headers set via writeHead. Updates the writeHead patch to use setHeader to set any headers before emitting this event.

For reference to Node's handling of setHeader arguments, see: https://github.com/joyent/node/blob/master/lib/http.js#L911
