### PR TITLE
Make middleware/query "self-aware".

### DIFF
--- a/lib/middleware/query.js
+++ b/lib/middleware/query.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - query
  * Copyright(c) 2011 TJ Holowaychuk
@@ -36,9 +35,12 @@ var qs = require('qs')
 
 module.exports = function query(options){
   return function query(req, res, next){
-    req.query = ~req.url.indexOf('?')
-      ? qs.parse(parse(req.url).query, options)
-      : {};
+    if (!req.query) {
+      req.query = ~req.url.indexOf('?')
+        ? qs.parse(parse(req.url).query, options)
+        : {};
+    }
+
     next();
   };
 };


### PR DESCRIPTION
For parity with middleware/json et al, call `next()` if the query has already been parsed.
