### PR TITLE
Added support for 'content-disposition' header to connect.static() middleware.

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -39,8 +39,8 @@ var fs = require('fs')
  *    - `maxAge`   Browser cache maxAge in milliseconds. defaults to 0
  *    - `hidden`   Allow transfer of hidden files. defaults to false
  *    - `redirect`   Redirect to trailing "/" when the pathname is a dir
- *    - `contentDisposition`   Sets 'Content-Disposition: attachment; filename=<filename> header.
- *                             defaults to false
+ *    - `forceSaveAs`   Sets 'Content-Disposition: attachment; filename=<filename> header.
+ *                      defaults to false
  *
  * @param {String} root
  * @param {Object} options
@@ -113,7 +113,7 @@ var send = exports.send = function(req, res, next, options){
     , getOnly = options.getOnly
     , fn = options.callback
     , hidden = options.hidden
-    , contentDisposition = true === options.contentDisposition ? true : false
+    , forceSaveAs = true === options.forceSaveAs ? true : false
     , done;
 
   // replace next() with callback when available
@@ -175,7 +175,7 @@ var send = exports.send = function(req, res, next, options){
       res.setHeader('Content-Type', type + (charset ? '; charset=' + charset : ''));
     }
     res.setHeader('Accept-Ranges', 'bytes');
-    if (contentDisposition) res.setHeader('Content-Disposition', 'attachment; filename=' + basename( options.path ));
+    if (forceSaveAs) res.setHeader('Content-Disposition', 'attachment; filename=' + basename( options.path ));
 
     // conditional GET support
     if (utils.conditionalGET(req)) {

--- a/test/static.js
+++ b/test/static.js
@@ -83,7 +83,7 @@ describe('connect.static()', function(){
     })
   })
 
-  describe('content-disposition', function(){
+  describe('forceSaveAs adds header content-disposition', function(){
     it('should be not set by default', function(done){
       app.request()
       .get('/todo.txt')
@@ -93,10 +93,10 @@ describe('connect.static()', function(){
       })
     })
 
-    it('should add header content-dispostion when contentDisposition: true is given', function(done){
+    it('should add header content-dispostion when forceSaveAs: true is given', function(done){
       var app = connect();
 
-      app.use(connect.static(fixtures, { contentDisposition: true }));
+      app.use(connect.static(fixtures, { forceSaveAs: true }));
 
       app.request()
       .get('/todo.txt')


### PR DESCRIPTION
Not a huge deal, but I like having certain static routes to always tell the browser to do a 'save as' on the file instead of trying to open it. You can now set the option { contentDisposition: true } to set the header so that the browser does a 'save as'. Here is the description of the header: http://tools.ietf.org/html/rfc6266

This includes tests too.

The name of the option might not be the best though, maybe I should change it to "askSaveAs"?
