### PR TITLE
enable optional `reviver` function to be passed to JSON.parse

### DIFF
--- a/lib/middleware/json.js
+++ b/lib/middleware/json.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - json
  * Copyright(c) 2010 Sencha Inc.
@@ -21,6 +20,7 @@ var utils = require('../utils');
  * Options:
  *
  *   - `strict`  when `false` anything `JSON.parse()` accepts will be parsed
+ *   - `reviver`  used as the second "reviver" argument for JSON.parse
  *
  * @param {Object} options
  * @return {Function}
@@ -50,7 +50,7 @@ exports = module.exports = function(options){
     req.on('end', function(){
       if (strict && '{' != buf[0] && '[' != buf[0]) return next(utils.error(400));
       try {
-        req.body = JSON.parse(buf);
+        req.body = JSON.parse(buf, options.reviver);
         next();
       } catch (err){
         err.status = 400;


### PR DESCRIPTION
This is the other end of allowing a "replacer" function for `JSON.stringify`.
