### PR TITLE
Emit drain in compress middleware.

### DIFF
--- a/lib/middleware/compress.js
+++ b/lib/middleware/compress.js
@@ -134,7 +134,10 @@ module.exports = function compress(options) {
       stream.on('end', function(){
         end.call(res);
       });
-      
+
+      stream.on('drain', function() {
+        res.emit('drain');
+      });
     });
 
     next();


### PR DESCRIPTION
Fixes #541.

This doesn't address the fact that when underlying socket is full, we should be pausing res, but we don't. That's a performance thing though, whereas this causes the request to hang.
