### PR TITLE
use "finsh" event to write msg on response time

### DIFF
--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -144,9 +144,9 @@ exports = module.exports = function logger(options) {
     // proxy end to output logging
     } else {
       res.on('finish', function(chunk, encoding) {
-      	    var line = fmt(exports, req, res);
-	        if (null == line) return;
-	        stream.write(line + '\n', 'ascii');
+        var line = fmt(exports, req, res);
+        if (null == line) return;
+        stream.write(line + '\n', 'ascii');
       });
     }
 


### PR DESCRIPTION
I found the "finish" event in node0.6.15/lib/http.js line 813

``` javascript
OutgoingMessage.prototype._finish = function() {
  assert(this.connection);
  if (this instanceof ServerResponse) {
    DTRACE_HTTP_SERVER_RESPONSE(this.connection);
  } else {
    assert(this instanceof ClientRequest);
    DTRACE_HTTP_CLIENT_REQUEST(this, this.connection);
  }
  this.emit('finish');
};
```

Is it better to use it than override the original "res.end" ?
