### PR TITLE
Added support to csrf middle-ware for pre-flighted CORS request

### DIFF
--- a/lib/middleware/csrf.js
+++ b/lib/middleware/csrf.js
@@ -47,7 +47,7 @@ module.exports = function csrf(options) {
     var token = req.session._csrf || (req.session._csrf = utils.uid(24));
 
     // ignore GET & HEAD (for now)
-    if ('GET' == req.method || 'HEAD' == req.method) return next();
+    if ('GET' == req.method || 'HEAD' == req.method || 'OPTIONS' == req.method) return next();
 
     // determine value
     var val = value(req);


### PR DESCRIPTION
Hi there, 
    when using CORS, some browsers send a pre-flighted request with a request method called 'OPTIONS'.

This commit simply allows the csrf middle ware to allow the OPTIONS method.
