### PR TITLE
static middleware : add options.directoryIndex

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -103,6 +103,7 @@ var send = exports.send = function(req, res, next, options){
 
   // setup
   var maxAge = options.maxAge || 0
+    , directoryIndex = options.directoryIndex || 'index.html'
     , ranges = req.headers.range
     , head = 'HEAD' == req.method
     , get = 'GET' == req.method
@@ -135,7 +136,7 @@ var send = exports.send = function(req, res, next, options){
   if (!root && ~path.indexOf('..')) return next(utils.error(403));
   
   // index.html support
-  if ('/' == path[path.length - 1]) path += 'index.html';
+  if ('/' == path[path.length - 1]) path += directoryIndex;
   
   // join / normalize from optional root dir
   path = normalize(join(root, path));


### PR DESCRIPTION
added an optional 'directoryIndex' param to static middleware with 'index.html' as default.
