### PR TITLE
Updated `engines` to allow newer version of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,5 @@
     "dox": "*"
   },
   "main": "index",
-  "engines": { "node": ">= 0.5.0 < 0.7.0" }
+  "engines": { "node": ">= 0.5.0" }
 }


### PR DESCRIPTION
`npm install` inside of `express` fails on `connect` due to engine restrictions, in newer version of node. changing this to allow the 0.7.x versions to install connect / express.
