### PR TITLE
Fixed `ENOTDIR` error on `static` middleware

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -150,10 +150,10 @@ var send = exports.send = function(req, res, next, options){
     // mime type
     type = mime.lookup(path);
 
-    // ignore ENOENT
+    // ignore ENOENT, ENAMETOOLONG and ENOTDIR
     if (err) {
       if (fn) return fn(err);
-      return ('ENOENT' == err.code || 'ENAMETOOLONG' == err.code)
+      return ('ENOENT' == err.code || 'ENAMETOOLONG' == err.code || 'ENOTDIR' == err.code)
         ? next()
         : next(err);
     // redirect directory in case index.html is present

--- a/test/static.js
+++ b/test/static.js
@@ -254,6 +254,14 @@ describe('connect.static()', function(){
     })
   })
 
+  describe('on ENOTDIR', function(){
+    it('should next()', function(done) {
+      app.request()
+      .get('/todo.txt/a.php')
+      .expect(404, done);
+    })
+  })
+
   describe('when mounted', function(){
     it('should redirect relative to the originalUrl', function(done){
       var app = connect();


### PR DESCRIPTION
When request a not exists path like '/todo.txt/a.php', `static` middleware will cause a `ENOTDIR` error.
