### PR TITLE
Remove socket event listeners on callback

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -230,7 +230,11 @@ var send = exports.send = function(req, res, next, options){
 
     // callback
     if (fn) {
-      function callback(err) { done || fn(err); done = true }
+      function callback(err) {
+        done || fn(err);
+        done = true;
+        req.socket.removeListener("error", callback);
+      }
       req.on('close', callback);
       req.socket.on('error', callback);
       stream.on('error', callback);


### PR DESCRIPTION
Hi,

static middleware attaches a callback to `req.socket`'s error event, which causes an event listener leak due to reused sockets by keep-alive connections. Then the eventemitter starts logging;

```
warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
```

I was not sure if it would be better to just remove the event attachment but this removes the error event listener from `req.socket` when the request closes somehow.

This is related to Issue #527.
