### PR TITLE
regexp.test() is faster than string.match().

### DIFF
--- a/lib/middleware/compress.js
+++ b/lib/middleware/compress.js
@@ -26,8 +26,7 @@ exports.methods = {
  */
 
 exports.filter = function(req, res){
-  var type = res.getHeader('Content-Type') || '';
-  return type.match(/json|text|javascript/);
+  return /json|text|javascript/.test(res.getHeader('Content-Type'));
 };
 
 /**
@@ -41,8 +40,7 @@ exports.filter = function(req, res){
  *  replace the default logic of:
  *
  *     exports.filter = function(req, res){
- *       var type = res.getHeader('Content-Type') || '';
- *       return type.match(/json|text|javascript/);
+ *       return /json|text|javascript/.test(res.getHeader('Content-Type'));
  *     };
  *
  * Options:


### PR DESCRIPTION
To filter by Content-Type in compress middleware, regexp.test() should be more appropriate, because we only need a boolean test.
