### PR TITLE
use `cookie` package for cookie parsing and serialization

### DIFF
--- a/lib/middleware/cookieParser.js
+++ b/lib/middleware/cookieParser.js
@@ -10,7 +10,8 @@
  * Module dependencies.
  */
 
-var utils = require('./../utils');
+var utils = require('./../utils')
+  , cookie = require('cookie');
 
 /**
  * Cookie parser:
@@ -36,16 +37,16 @@ var utils = require('./../utils');
 
 module.exports = function cookieParser(secret){
   return function cookieParser(req, res, next) {
-    var cookie = req.headers.cookie;
     if (req.cookies) return next();
+    var cookieHeader = req.headers.cookie;
 
     req.secret = secret;
     req.cookies = {};
     req.signedCookies = {};
     
-    if (cookie) {
+    if (cookieHeader) {
       try {
-        req.cookies = utils.parseCookie(cookie);
+        req.cookies = cookie.parse(cookieHeader);
         if (secret) {
           req.signedCookies = utils.parseSignedCookies(req.cookies, secret);
           var obj = utils.parseJSONCookies(req.signedCookies);

--- a/lib/middleware/cookieSession.js
+++ b/lib/middleware/cookieSession.js
@@ -86,7 +86,7 @@ module.exports = function cookieSession(options){
 
       // set-cookie
       val = utils.sign(val, req.secret);
-      val = utils.serializeCookie(key, val, cookie);
+      val = cookie.serialize(key, val);
       debug('set-cookie %j', cookie);
       res.setHeader('Set-Cookie', val);
     });

--- a/lib/middleware/session/cookie.js
+++ b/lib/middleware/session/cookie.js
@@ -10,7 +10,8 @@
  * Module dependencies.
  */
 
-var utils = require('../../utils');
+var utils = require('../../utils')
+  , cookie = require('cookie');
 
 /**
  * Initialize a new `Cookie` with the given `options`.
@@ -111,7 +112,7 @@ Cookie.prototype = {
    */
 
   serialize: function(name, val){
-    return utils.serializeCookie(name, val, this.data);
+    return cookie.serialize(name, val, this.data);
   },
 
   /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -213,69 +213,6 @@ exports.parseJSONCookies = function(obj){
 };
 
 /**
- * Parse the given cookie string into an object.
- *
- * @param {String} str
- * @return {Object}
- * @api private
- */
-
-exports.parseCookie = function(str){
-  var obj = {}
-    , pairs = str.split(/[;,] */);
-  for (var i = 0, len = pairs.length; i < len; ++i) {
-    var pair = pairs[i]
-      , eqlIndex = pair.indexOf('=')
-      , key = pair.substr(0, eqlIndex).trim()
-      , val = pair.substr(++eqlIndex, pair.length).trim();
-
-    // quoted values
-    if ('"' == val[0]) val = val.slice(1, -1);
-
-    // only assign once
-    if (undefined == obj[key]) {
-      val = val.replace(/\+/g, ' ');
-      try {
-        obj[key] = decodeURIComponent(val);
-      } catch (err) {
-        if (err instanceof URIError) {
-          obj[key] = val;
-        } else {
-          throw err;
-        }
-      }
-    }
-  }
-  return obj;
-};
-
-/**
- * Serialize the given object into a cookie string.
- *
- *      utils.serializeCookie('name', 'tj', { httpOnly: true })
- *      // => "name=tj; httpOnly"
- *
- * @param {String} name
- * @param {String} val
- * @param {Object} obj
- * @return {String}
- * @api private
- */
-
-exports.serializeCookie = function(name, val, obj){
-  var pairs = [name + '=' + encodeURIComponent(val)]
-    , obj = obj || {};
-
-  if (obj.domain) pairs.push('domain=' + obj.domain);
-  if (obj.path) pairs.push('path=' + obj.path);
-  if (obj.expires) pairs.push('expires=' + obj.expires.toUTCString());
-  if (obj.httpOnly) pairs.push('httpOnly');
-  if (obj.secure) pairs.push('secure');
-
-  return pairs.join('; ');
-};
-
-/**
  * Pause `data` and `end` events on the given `obj`.
  * Middleware performing async tasks _should_ utilize
  * this utility (or similar), to re-emit data once

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "mime": "1.2.4",
     "formidable": "1.0.9",
     "crc": "0.1.0",
+    "cookie": "0.0.1",
     "debug": "*"
   },
   "devDependencies": {

--- a/test/cookieSession.js
+++ b/test/cookieSession.js
@@ -100,8 +100,8 @@ describe('connect.cookieSession()', function(){
       .get('/')
       .end(function(res){
         var cookie = sess(res);
-        cookie.should.include('path=/');
-        cookie.should.include('httpOnly');
+        cookie.should.include('Path=/');
+        cookie.should.include('HttpOnly');
         done();
       })
     })
@@ -117,8 +117,8 @@ describe('connect.cookieSession()', function(){
       .get('/')
       .end(function(res){
         var cookie = sess(res);
-        cookie.should.include('path=/admin');
-        cookie.should.not.include('httpOnly');
+        cookie.should.include('Path=/admin');
+        cookie.should.not.include('HttpOnly');
         done();
       })
     })
@@ -138,8 +138,8 @@ describe('connect.cookieSession()', function(){
       .get('/')
       .end(function(res){
         var cookie = sess(res);
-        cookie.should.include('path=/');
-        cookie.should.not.include('httpOnly');
+        cookie.should.include('Path=/');
+        cookie.should.not.include('HttpOnly');
         done();
       })
     })

--- a/test/session.js
+++ b/test/session.js
@@ -15,7 +15,7 @@ function sid(res) {
 }
 
 function expires(res) {
-  return res.headers['set-cookie'][0].match(/expires=([^;]+)/)[1];
+  return res.headers['set-cookie'][0].match(/Expires=([^;]+)/)[1];
 }
 
 var app = connect()
@@ -306,8 +306,8 @@ describe('connect.session()', function(){
           .get('/')
           .set('X-Forwarded-Proto', 'https')
           .end(function(res){
-            res.headers['set-cookie'][0].should.not.include('httpOnly');
-            res.headers['set-cookie'][0].should.include('secure');
+            res.headers['set-cookie'][0].should.not.include('HttpOnly');
+            res.headers['set-cookie'][0].should.include('Secure');
             done();
           });
         })
@@ -324,7 +324,7 @@ describe('connect.session()', function(){
           .get('/')
           .end(function(res){
             var cookie = res.headers['set-cookie'][0];
-            cookie.should.not.include('expires');
+            cookie.should.not.include('Expires');
             done();
           });
         })
@@ -365,10 +365,10 @@ describe('connect.session()', function(){
           .get('/')
           .end(function(res){
             var cookie = res.headers['set-cookie'][0];
-            cookie.should.not.include('httpOnly');
-            cookie.should.not.include('secure');
-            cookie.should.include('path=/admin');
-            cookie.should.include('expires');
+            cookie.should.not.include('HttpOnly');
+            cookie.should.not.include('Secure');
+            cookie.should.include('Path=/admin');
+            cookie.should.include('Expires');
             done();
           });
         })
@@ -452,7 +452,7 @@ describe('connect.session()', function(){
             app.request()
             .get('/')
             .end(function(res){
-              res.headers['set-cookie'][0].should.not.include('expires=');
+              res.headers['set-cookie'][0].should.not.include('Expires=');
               done();
             });
           })

--- a/test/utils.js
+++ b/test/utils.js
@@ -26,45 +26,6 @@ describe('utils.parseCacheControl(str)', function(){
   })
 })
 
-describe('utils.parseCookie(str)', function(){
-  it('should parse cookies', function(){
-    utils.parseCookie('foo=bar').should.eql({ foo: 'bar' });
-    utils.parseCookie('sid=123').should.eql({ sid: '123' });
-
-    utils.parseCookie('FOO   = bar;  baz    =  raz')
-      .should.eql({ FOO: 'bar', baz: 'raz' });  
-
-    utils.parseCookie('fbs="uid=0987654321&name=Test+User"')
-      .should.eql({ fbs: 'uid=0987654321&name=Test User' });
-
-    utils.parseCookie('email=tobi%2Bferret@foo.com')
-      .should.eql({ email: 'tobi+ferret@foo.com' });
-  })
-})
-
-describe('utils.serializeCookie(name, val[, options])', function(){
-  it('should serialize cookies', function(){
-    utils
-      .serializeCookie('foo', 'bar', { path: '/' })
-      .should.equal('foo=bar; path=/');
-
-    utils
-      .serializeCookie('foo', 'bar', { secure: true })
-      .should.equal('foo=bar; secure');
-
-    utils
-      .serializeCookie('foo', 'bar', { secure: false })
-      .should.equal('foo=bar');
-
-    utils
-      .serializeCookie('Foo', 'foo bar')
-      .should.equal('Foo=foo%20bar');
-
-    utils.parseCookie(utils.serializeCookie('fbs', 'uid=123&name=Test User'))
-      .should.eql({ fbs: 'uid=123&name=Test User' });
-  })
-})
-
 describe('utils.[un]sign()', function(){
   it('should sign & unsign values', function(){
     var val = utils.sign('something', 'foo');


### PR DESCRIPTION
Cookie parsing and serialization per the RFC is a well defined function
that is better provided by a simple library.
