### PR TITLE
add `secret` option to `session` middleware

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -59,13 +59,14 @@ var warning = 'Warning: connection.session() MemoryStore is not\n'
  * Examples:
  *
  *     connect()
- *       .use(connect.cookieParser('keyboard cat'))
- *       .use(connect.session({ key: 'sid', cookie: { secure: true }}))
+ *       .use(connect.cookieParser())
+ *       .use(connect.session({ secret: 'keyboard cat', key: 'sid', cookie: { secure: true }}))
  *
  * Options:
  *
  *   - `key` cookie name defaulting to `connect.sid`
  *   - `store` session store instance
+ *   - `secret` session cookie is signed with this secret to prevent tampering
  *   - `cookie` session cookie settings, defaulting to `{ path: '/', httpOnly: true, maxAge: null }`
  *   - `proxy` trust the reverse proxy when setting secure cookies (via "x-forwarded-proto")
  *
@@ -83,8 +84,8 @@ var warning = 'Warning: connection.session() MemoryStore is not\n'
  *
  *       connect()
  *         .use(connect.favicon())
- *         .use(connect.cookieParser('keyboard cat'))
- *         .use(connect.session({ cookie: { maxAge: 60000 }}))
+ *         .use(connect.cookieParser())
+ *         .use(connect.session({ secret: 'keyboard cat', cookie: { maxAge: 60000 }}))
  *         .use(function(req, res, next){
  *           var sess = req.session;
  *           if (sess.views) {
@@ -208,8 +209,12 @@ function session(options){
     // self-awareness
     if (req.session) return next();
 
+    // backwards compatibility for signed cookies
+    // req.secret is passed from the cookie parser middleware
+    var secret = options.secret || req.secret;
+
     // ensure secret is available or bail
-    if (!req.secret) throw new Error('connect.cookieParser("secret") required for security when using sessions');
+    if (!secret) throw new Error('`secret` option required for sessions');
 
     // parse url
     var url = parse(req)
@@ -219,6 +224,16 @@ function session(options){
     // expose store
     req.sessionStore = store;
 
+    // grab the session cookie value and check the signature
+    var rawCookie = req.cookies[key];
+
+    // get signedCookies for backwards compat with signed cookies
+    var unsignedCookie = req.signedCookies[key];
+
+    if (!unsignedCookie && rawCookie) {
+      unsignedCookie = utils.parseSignedCookie(rawCookie, secret);
+    }
+
     // set-cookie
     res.on('header', function(){
       if (!req.session) return;
@@ -226,7 +241,7 @@ function session(options){
         , proto = (req.headers['x-forwarded-proto'] || '').toLowerCase()
         , tls = req.connection.encrypted || (trustProxy && 'https' == proto)
         , secured = cookie.secure && tls
-        , isNew = req.signedCookies[key] != req.sessionID;
+        , isNew = unsignedCookie != req.sessionID;
 
       // only send secure cookies via https
       if (cookie.secure && !secured) return debug('not secured');
@@ -239,7 +254,7 @@ function session(options){
         return debug('unmodified session');
       }
 
-      var val = 's:' + utils.sign(req.sessionID, req.secret);
+      var val = 's:' + utils.sign(req.sessionID, secret);
       val = cookie.serialize(key, val);
       debug('set-cookie %s', val);
       res.setHeader('Set-Cookie', val);
@@ -264,7 +279,7 @@ function session(options){
     }
 
     // get the sessionID from the cookie
-    req.sessionID = req.signedCookies[key];
+    req.sessionID = unsignedCookie;
 
     // generate a session if the browser doesn't send a sessionID
     if (!req.sessionID) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -180,6 +180,24 @@ exports.parseSignedCookies = function(obj, secret){
 };
 
 /**
+ * Parse a signed cookie string, return the decoded value
+ *
+ * @param {String} str signed cookie string
+ * @param {String} secret
+ * @return {String} decoded value
+ * @api private
+ */
+
+exports.parseSignedCookie = function(str, secret){
+  // if not signed, return cookie string
+  if (0 !== str.indexOf('s:')) {
+    return str;
+  }
+
+  return exports.unsign(str.slice(2), secret);
+};
+
+/**
  * Parse JSON cookies.
  *
  * @param {Object} obj

--- a/test/session.js
+++ b/test/session.js
@@ -19,8 +19,8 @@ function expires(res) {
 }
 
 var app = connect()
-  .use(connect.cookieParser('keyboard cat'))
-  .use(connect.session({ cookie: { maxAge: min }}))
+  .use(connect.cookieParser())
+  .use(connect.session({ secret: 'keyboard cat', cookie: { maxAge: min }}))
   .use(respond);
 
 describe('connect.session()', function(){
@@ -34,8 +34,8 @@ describe('connect.session()', function(){
     describe('when enabled', function(){
       it('should trust X-Forwarded-Proto', function(done){
         var app = connect()
-          .use(connect.cookieParser('keyboard cat'))
-          .use(connect.session({ proxy: true, cookie: { secure: true, maxAge: 5 }}))
+          .use(connect.cookieParser())
+          .use(connect.session({ secret: 'keyboard cat', proxy: true, cookie: { secure: true, maxAge: 5 }}))
           .use(respond);
 
         app.request()
@@ -51,8 +51,8 @@ describe('connect.session()', function(){
     describe('when disabled', function(){
       it('should not trust X-Forwarded-Proto', function(done){
         var app = connect()
-          .use(connect.cookieParser('keyboard cat'))
-          .use(connect.session({ cookie: { secure: true, maxAge: min }}))
+          .use(connect.cookieParser())
+          .use(connect.session({ secret: 'keyboard cat', cookie: { secure: true, maxAge: min }}))
           .use(respond);
 
         app.request()
@@ -79,8 +79,8 @@ describe('connect.session()', function(){
 
     it('should allow overriding', function(done){
       var app = connect()
-        .use(connect.cookieParser('keyboard cat'))
-        .use(connect.session({ key: 'sid', cookie: { maxAge: min }}))
+        .use(connect.cookieParser())
+        .use(connect.session({ secret: 'keyboard cat', key: 'sid', cookie: { maxAge: min }}))
         .use(respond);
 
       app.request()
@@ -97,8 +97,8 @@ describe('connect.session()', function(){
     var n = 0;
 
     var app = connect()
-      .use(connect.cookieParser('keyboard cat'))
-      .use(connect.session({ cookie: { maxAge: min }}))
+      .use(connect.cookieParser())
+      .use(connect.session({ secret: 'keyboard cat', cookie: { maxAge: min }}))
       .use(function(req, res){
         req.session.count = ++n;
         res.end();
@@ -135,8 +135,8 @@ describe('connect.session()', function(){
     var n = 0;
 
     var app = connect()
-      .use(connect.cookieParser('keyboard cat'))
-      .use(connect.session({ cookie: { maxAge: min }}))
+      .use(connect.cookieParser())
+      .use(connect.session({ secret: 'keyboard cat', cookie: { maxAge: min }}))
       .use(function(req, res){
         req.session.count = ++n;
         res.end();
@@ -166,14 +166,14 @@ describe('connect.session()', function(){
   describe('req.session', function(){
     it('should persist', function(done){
       var app = connect()
-        .use(connect.cookieParser('keyboard cat'))
-        .use(connect.session({ cookie: { maxAge: min }}))
+        .use(connect.cookieParser())
+        .use(connect.session({ secret: 'keyboard cat', cookie: { maxAge: min }}))
         .use(function(req, res, next){
           req.session.count = req.session.count || 0;
           req.session.count++;
           res.end(req.session.count.toString());
         });
-        
+
       app.request()
       .get('/')
       .end(function(res){
@@ -194,8 +194,8 @@ describe('connect.session()', function(){
       var modify = true;
 
       var app = connect()
-        .use(connect.cookieParser('keyboard cat'))
-        .use(connect.session({ cookie: { maxAge: min }}))
+        .use(connect.cookieParser())
+        .use(connect.session({ secret: 'keyboard cat', cookie: { maxAge: min }}))
         .use(function(req, res, next){
           if (modify) {
             req.session.count = req.session.count || 0;
@@ -241,8 +241,8 @@ describe('connect.session()', function(){
     describe('.destroy()', function(){
       it('should destroy the previous session', function(done){
         var app = connect()
-          .use(connect.cookieParser('keyboard cat'))
-          .use(connect.session())
+          .use(connect.cookieParser())
+          .use(connect.session({ secret: 'keyboard cat' }))
           .use(function(req, res, next){
             req.session.destroy(function(err){
               if (err) throw err;
@@ -263,8 +263,8 @@ describe('connect.session()', function(){
     describe('.regenerate()', function(){
       it('should destroy/replace the previous session', function(done){
         var app = connect()
-          .use(connect.cookieParser('keyboard cat'))
-          .use(connect.session({ cookie: { maxAge: min }}))
+          .use(connect.cookieParser())
+          .use(connect.session({ secret: 'keyboard cat', cookie: { maxAge: min }}))
           .use(function(req, res, next){
             var id = req.session.id;
             req.session.regenerate(function(err){
@@ -294,8 +294,8 @@ describe('connect.session()', function(){
       describe('.*', function(){
         it('should serialize as parameters', function(done){
           var app = connect()
-            .use(connect.cookieParser('keyboard cat'))
-            .use(connect.session({ proxy: true, cookie: { maxAge: min }}))
+            .use(connect.cookieParser())
+            .use(connect.session({ secret: 'keyboard cat', proxy: true, cookie: { maxAge: min }}))
             .use(function(req, res, next){
               req.session.cookie.httpOnly = false;
               req.session.cookie.secure = true;
@@ -314,8 +314,8 @@ describe('connect.session()', function(){
 
         it('should default to a browser-session length cookie', function(done){
           var app = connect()
-            .use(connect.cookieParser('keyboard cat'))
-            .use(connect.session({ cookie: { path: '/admin' }}))
+            .use(connect.cookieParser())
+            .use(connect.session({ secret: 'keyboard cat', cookie: { path: '/admin' }}))
             .use(function(req, res, next){
               res.end();
             });
@@ -331,8 +331,8 @@ describe('connect.session()', function(){
 
         it('should Set-Cookie only once for browser-session cookies', function(done){
           var app = connect()
-            .use(connect.cookieParser('keyboard cat'))
-            .use(connect.session({ cookie: { path: '/admin' }}))
+            .use(connect.cookieParser())
+            .use(connect.session({ secret: 'keyboard cat', cookie: { path: '/admin' }}))
             .use(function(req, res, next){
               res.end();
             });
@@ -354,8 +354,8 @@ describe('connect.session()', function(){
 
         it('should override defaults', function(done){
           var app = connect()
-            .use(connect.cookieParser('keyboard cat'))
-            .use(connect.session({ cookie: { path: '/admin', httpOnly: false, secure: true, maxAge: 5000 }}))
+            .use(connect.cookieParser())
+            .use(connect.session({ secret: 'keyboard cat', cookie: { path: '/admin', httpOnly: false, secure: true, maxAge: 5000 }}))
             .use(function(req, res, next){
               req.session.cookie.secure = false;
               res.end();
@@ -377,8 +377,8 @@ describe('connect.session()', function(){
       describe('.secure', function(){
         it('should not set-cookie when insecure', function(done){
           var app = connect()
-            .use(connect.cookieParser('keyboard cat'))
-            .use(connect.session())
+            .use(connect.cookieParser())
+            .use(connect.session({ secret: 'keyboard cat' }))
             .use(function(req, res, next){
               req.session.cookie.secure = true;
               res.end();
@@ -396,8 +396,8 @@ describe('connect.session()', function(){
       describe('.maxAge', function(){
         it('should set relative in milliseconds', function(done){
           var app = connect()
-            .use(connect.cookieParser('keyboard cat'))
-            .use(connect.session())
+            .use(connect.cookieParser())
+            .use(connect.session({ secret: 'keyboard cat' }))
             .use(function(req, res, next){
               req.session.cookie.maxAge = 2000;
               res.end();
@@ -423,8 +423,8 @@ describe('connect.session()', function(){
         describe('when given a Date', function(){
           it('should set absolute', function(done){
             var app = connect()
-              .use(connect.cookieParser('keyboard cat'))
-              .use(connect.session())
+              .use(connect.cookieParser())
+              .use(connect.session({ secret: 'keyboard cat' }))
               .use(function(req, res, next){
                 req.session.cookie.expires = new Date(0);
                 res.end();
@@ -442,8 +442,8 @@ describe('connect.session()', function(){
         describe('when null', function(){
           it('should be a browser-session cookie', function(done){
             var app = connect()
-              .use(connect.cookieParser('keyboard cat'))
-              .use(connect.session())
+              .use(connect.cookieParser())
+              .use(connect.session({ secret: 'keyboard cat' }))
               .use(function(req, res, next){
                 req.session.cookie.expires = null;
                 res.end();
@@ -460,6 +460,31 @@ describe('connect.session()', function(){
       })
     })
 
-  })
+    it('should work with signed cookies', function(done){
+      var app = connect()
+        .use(connect.cookieParser('keyboard cat'))
+        .use(connect.session({ cookie: { maxAge: min }}))
+        .use(function(req, res, next){
+          req.session.count = req.session.count || 0;
+          req.session.count++;
+          res.end(req.session.count.toString());
+        });
 
+      app.request()
+      .get('/')
+      .end(function(res){
+        res.body.should.equal('1');
+
+        app.request()
+        .get('/')
+        .set('Cookie', 'connect.sid=' + sid(res))
+        .end(function(res){
+          var id = sid(res);
+          res.body.should.equal('2');
+          done();
+        });
+      });
+    })
+
+  })
 })


### PR DESCRIPTION
This decouples `session` and `cookieParser` middleware by not requiring
the `cookieParser` middleware to do signed cookies for the session
middleware. This separates middleware responsibility and allows each
middleware to be a bit more self contained and implement signing within
session as needed.

Eventually this will allow the `cookieParser` middleware to just do the
basic functions of cookie parsing instead of trying to do too much.
