### PR TITLE
add `secret` option to `cookieSession` middleware

### DIFF
--- a/lib/middleware/cookieParser.js
+++ b/lib/middleware/cookieParser.js
@@ -43,17 +43,16 @@ module.exports = function cookieParser(secret){
     req.secret = secret;
     req.cookies = {};
     req.signedCookies = {};
-    
+
     if (cookies) {
       try {
         req.cookies = cookie.parse(cookies);
         if (secret) {
           req.signedCookies = utils.parseSignedCookies(req.cookies, secret);
           var obj = utils.parseJSONCookies(req.signedCookies);
-          req.signedCookies = obj.cookies;
-          req.cookieHashes = obj.hashes;
+          req.signedCookies = obj;
         }
-        req.cookies = utils.parseJSONCookies(req.cookies).cookies;
+        req.cookies = utils.parseJSONCookies(req.cookies);
       } catch (err) {
         return next(err);
       }

--- a/lib/middleware/cookieSession.js
+++ b/lib/middleware/cookieSession.js
@@ -24,12 +24,13 @@ var env = process.env.NODE_ENV;
  *   Cookie session middleware.
  *
  *      var app = connect();
- *      app.use(connect.cookieParser('tobo!'));
- *      app.use(connect.cookieSession({ cookie: { maxAge: 60 * 60 * 1000 }}));
+ *      app.use(connect.cookieParser());
+ *      app.use(connect.cookieSession({ secret: 'tobo!', cookie: { maxAge: 60 * 60 * 1000 }}));
  *
  * Options:
  *
  *   - `key` cookie name defaulting to `connect.sess`
+ *   - `secret` prevents cookie tampering
  *   - `cookie` session cookie settings, defaulting to `{ path: '/', httpOnly: true, maxAge: null }`
  *   - `proxy` trust the reverse proxy when setting secure cookies (via "x-forwarded-proto")
  *
@@ -53,7 +54,26 @@ module.exports = function cookieSession(options){
     , trustProxy = options.proxy;
 
   return function cookieSession(req, res, next) {
-    req.session = req.signedCookies[key] || {};
+
+    // req.secret is for backwards compatibility
+    var secret = options.secret || req.secret;
+    if (!secret) throw new Error('`secret` option required for cookie sessions');
+
+    // default session
+    req.session = {};
+
+    // grab the session cookie value, check signature, and unpack the payload
+    var originalHash;
+    var rawCookie = req.cookies[key];
+    if (rawCookie) {
+      var unsigned = utils.parseSignedCookie(rawCookie, secret);
+
+      // store hash value, we will only set the cookie if the hash changes
+      originalHash = crc16(unsigned);
+
+      req.session = utils.parseJSONCookie(unsigned) || {};
+    }
+
     req.session.cookie = new Cookie(cookie);
 
     res.on('header', function(){
@@ -79,13 +99,11 @@ module.exports = function cookieSession(options){
       debug('serializing %j', req.session);
       var val = 'j:' + JSON.stringify(req.session);
 
-      // compare hashes
-      var originalHash = req.cookieHashes && req.cookieHashes[key];
-      var hash = crc16(val);
-      if (originalHash == hash) return debug('unmodified session');
+      // compare hashes, no need to set-cookie if unchanged
+      if (originalHash == crc16(val)) return debug('unmodified session');
 
       // set-cookie
-      val = 's:' + utils.sign(val, req.secret);
+      val = 's:' + utils.sign(val, secret);
       val = cookie.serialize(key, val);
       debug('set-cookie %j', cookie);
       res.setHeader('Set-Cookie', val);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,6 @@
 
 var http = require('http')
   , crypto = require('crypto')
-  , crc16 = require('crc').crc16
   , parse = require('url').parse
   , Path = require('path')
   , fs = require('fs');
@@ -206,25 +205,39 @@ exports.parseSignedCookie = function(str, secret){
  */
 
 exports.parseJSONCookies = function(obj){
-  var hashes = {};
 
   Object.keys(obj).forEach(function(key){
     var val = obj[key];
-    if (0 == val.indexOf('j:')) {
-      try {
-        hashes[key] = crc16(val); // only crc json cookies for now
-        obj[key] = JSON.parse(val.slice(2));
-      } catch (err) {
-        // nothing
-      }
+    var res = exports.parseJSONCookie(val);
+    if (res) {
+      obj[key] = res;
     }
   });
 
-  return {
-    cookies: obj,
-    hashes: hashes
-  };
+  return obj;
 };
+
+/**
+ * Parse JSON cookie string
+ *
+ * @param {String} str
+ * @return {Object} Parsed object or null if not json cookie
+ * @api private
+ */
+
+exports.parseJSONCookie = function(str) {
+  if (0 !== str.indexOf('j:')) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(str.slice(2));
+  } catch (err) {
+    // no op
+  }
+
+  return null;
+}
 
 /**
  * Pause `data` and `end` events on the given `obj`.


### PR DESCRIPTION
This decouples `cookieParser` and `cookieSession` by not requiring the
`cookieParser` to handle the `cookieSession` signed cookies. This allows
the `cookieParser` middleware to be simpler by not having to perform
hashing. It also keeps the cookie session functionality contained
withing the `cookieSession` middleware.

cookieHashes has been removed as it is no longer needed. The hashing was
only done for the `cookieSession` middleware
