### PR TITLE
Fix server error for clients that send If-Modified-Since headers.

### DIFF
--- a/lib/middleware/staticCache.js
+++ b/lib/middleware/staticCache.js
@@ -154,7 +154,7 @@ function respondFromCache(req, res, cacheEntry) {
       break;
     case 'GET':
       if (utils.conditionalGET(req) && !utils.modified(req, res, headers)) {
-        header['content-length'] = 0;
+        headers['content-length'] = 0;
         res.writeHead(304, headers);
         res.end();
       } else {

--- a/test/staticCache.js
+++ b/test/staticCache.js
@@ -52,6 +52,20 @@ describe('connect.staticCache()', function(){
     });
   })
 
+  it('should return 304 response if not modified', function(done){
+    app.request()
+    .get('/todo.txt')
+    .end(function(res){
+      var req = app.request()
+      req.header["If-Modified-Since"] = new Date(new Date().getTime() + 100).toString();
+      req.get('/todo.txt')
+      .end(function(res){
+        res.statusCode.should.equal(304);
+        done();
+      });
+    });
+  })
+
   it('should serve the contents on GET', function(done){
     app.request()
     .get('/todo.txt')


### PR DESCRIPTION
Any client that sends an `If-Modified-Since` header to an app that uses the `staticCache` middleware will get 500 server errors due to a mistake in `respondFromCache`.

This fixes the problem and includes a test case that checks for correct 304 responses when a static file is not modified.

I imagine this affects any app that uses the staticCache middleware and is accessed by such a client (which includes, at least, some versions of IE).
