### PR TITLE
BUG: 1.8.7 missing require('./utils') in lib/http.js

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -12,6 +12,7 @@
 
 var http = require('http')
   , parse = require('url').parse
+  , utils = require('./utils')
   , assert = require('assert');
 
 // environment


### PR DESCRIPTION
lib/http.js uses `utils.escape()` but does not require('./utils'), thus throwing a ReferenceError.
