### PR TITLE
Remaining req parameter for Cookie constructor

### DIFF
--- a/lib/middleware/session/store.js
+++ b/lib/middleware/session/store.js
@@ -78,7 +78,7 @@ Store.prototype.createSession = function(req, sess){
   var expires = sess.cookie.expires
     , orig = sess.cookie.originalMaxAge
     , update = null == update ? true : false;
-  sess.cookie = new Cookie(req, sess.cookie);
+  sess.cookie = new Cookie(sess.cookie);
   if ('string' == typeof expires) sess.cookie.expires = new Date(expires);
   sess.cookie.originalMaxAge = orig;
   req.session = new Session(req, sess);


### PR DESCRIPTION
This one was left behind when you guys removed the "req" parameter for Cookie constructor. The worst part is, this causes "path" field in req object to be merged into session cookies, creating multiple session cookies for each page of the website :) ( check this: http://d.pr/i/qVTL ). 

I believe, it is required to change the session key in case anyone used this release in production.

Related to #574
