### PR TITLE
don't send 304 on responses that would otherwise not have a 2xx or 304 s...

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -181,9 +181,12 @@ var send = exports.send = function(req, res, next, options){
 
     // conditional GET support
     if (utils.conditionalGET(req)) {
-      if (fresh(req.headers, res._headers)) {
-        req.emit('static');
-        return utils.notModified(res);
+      // only use cache if original response would have had a status code of 2xx or 304 (see RFC 2616 section 14.25 and 14.26)
+      if ((res.statusCode >= 200 && res.statusCode < 300) || res.statusCode === 304) {
+        if (fresh(req.headers, res._headers)) {
+          req.emit('static');
+          return utils.notModified(res);
+        }
       }
     }
 


### PR DESCRIPTION
according to the RFC no 304 should be sent when the response without the conditional request headers should have resulted in another status code than 2xx or 304 (or even <> 200 in case of only a If-Modified-Since header).

I encountered this problem while sending a 403 on pages where the user needs to be logged in and serving a static login.html file (so the static file is only served if the user is not logged in).
