### PR TITLE
if request contains both if-modified-since and if-none-match, both shoul...

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -293,22 +293,30 @@ exports.modified = function(req, res, headers) {
 
   if (noneMatch) noneMatch = noneMatch.split(/ *, */);
 
-  // check If-None-Match
-  if (noneMatch && etag && ~noneMatch.indexOf(etag)) {
-    return false;
+  var etagOk = true;
+  // check ETag
+  if (noneMatch) {
+    etagOk = false;
+    if (etag && ~noneMatch.indexOf(etag)) {
+      etagOk = true;
+    }
   }
 
+  var ifModified = true;
   // check If-Modified-Since
   if (modifiedSince && lastModified) {
     modifiedSince = new Date(modifiedSince);
     lastModified = new Date(lastModified);
     // Ignore invalid dates
     if (!isNaN(modifiedSince.getTime())) {
-      if (lastModified <= modifiedSince) return false;
+      ifModified = false;
+      if (lastModified <= modifiedSince) {
+        ifModified = true;
+      }
     }
   }
-  
-  return true;
+
+  return !(etagOk && ifModified);
 };
 
 /**


### PR DESCRIPTION
if both if-modified-since and if-none-match are given in the client request, both headers should hold in order to give a 304. If one of both headers does not hold, a 304 can't be send.

according to http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.3.4
