### PR TITLE
enable size+mtime etags on static resources

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -167,6 +167,7 @@ var send = exports.send = function(req, res, next, options){
     }
 
     // header fields
+    if (!res.getHeader('ETag')) res.setHeader('ETag', utils.etag(stat));
     if (!res.getHeader('Date')) res.setHeader('Date', new Date().toUTCString());
     if (!res.getHeader('Cache-Control')) res.setHeader('Cache-Control', 'public, max-age=' + (maxAge / 1000));
     if (!res.getHeader('Last-Modified')) res.setHeader('Last-Modified', stat.mtime.toUTCString());


### PR DESCRIPTION
enable etag by default on static files, based on mtime + size of the file
