### PR TITLE
remove `utils.merge` in favor of `xtend` module

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -15,7 +15,8 @@ var EventEmitter = require('events').EventEmitter
   , utils = require('./utils')
   , path = require('path')
   , basename = path.basename
-  , fs = require('fs');
+  , fs = require('fs')
+  , xtend = require('xtend');
 
 // node patches
 
@@ -64,8 +65,8 @@ exports.utils = utils;
 
 function createServer() {
   function app(req, res){ app.handle(req, res); }
-  utils.merge(app, proto);
-  utils.merge(app, EventEmitter.prototype);
+  xtend(app, proto);
+  xtend(app, EventEmitter.prototype);
   app.route = '/';
   app.stack = [];
   for (var i = 0; i < arguments.length; ++i) {

--- a/lib/middleware/session/cookie.js
+++ b/lib/middleware/session/cookie.js
@@ -10,8 +10,8 @@
  * Module dependencies.
  */
 
-var utils = require('../../utils')
-  , cookie = require('cookie');
+var cookie = require('cookie')
+  , xtend = require('xtend');
 
 /**
  * Initialize a new `Cookie` with the given `options`.
@@ -25,7 +25,7 @@ var Cookie = module.exports = function Cookie(options) {
   this.path = '/';
   this.maxAge = null;
   this.httpOnly = true;
-  if (options) utils.merge(this, options);
+  if (options) xtend(this, options);
   this.originalMaxAge = undefined == this.originalMaxAge
     ? this.maxAge
     : this.originalMaxAge;

--- a/lib/middleware/session/session.js
+++ b/lib/middleware/session/session.js
@@ -10,7 +10,7 @@
  * Module dependencies.
  */
 
-var utils = require('../../utils');
+var xtend = require('xtend');
 
 /**
  * Create a new `Session` with the given request and `data`.
@@ -23,7 +23,7 @@ var utils = require('../../utils');
 var Session = module.exports = function Session(req, data) {
   Object.defineProperty(this, 'req', { value: req });
   Object.defineProperty(this, 'id', { value: req.sessionID });
-  if ('object' == typeof data) utils.merge(this, data);
+  if ('object' == typeof data) xtend(this, data);
 };
 
 /**

--- a/lib/middleware/staticCache.js
+++ b/lib/middleware/staticCache.js
@@ -14,7 +14,8 @@ var http = require('http')
   , Cache = require('../cache')
   , fresh = require('fresh')
   , url = require('url')
-  , fs = require('fs');
+  , fs = require('fs')
+  , xtend = require('xtend');
 
 /**
  * Static cache:
@@ -143,7 +144,7 @@ module.exports = function staticCache(options){
 
 function respondFromCache(req, res, cacheEntry) {
   var status = cacheEntry[0]
-    , headers = utils.merge({}, cacheEntry[1])
+    , headers = xtend({}, cacheEntry[1])
     , content = cacheEntry.slice(2);
 
   headers.age = (new Date - new Date(headers.date)) / 1000 || 0;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,30 +65,6 @@ exports.md5 = function(str, encoding){
 };
 
 /**
- * Merge object b with object a.
- *
- *     var a = { foo: 'bar' }
- *       , b = { bar: 'baz' };
- *     
- *     utils.merge(a, b);
- *     // => { foo: 'bar', bar: 'baz' }
- *
- * @param {Object} a
- * @param {Object} b
- * @return {Object}
- * @api private
- */
-
-exports.merge = function(a, b){
-  if (a && b) {
-    for (var key in b) {
-      a[key] = b[key];
-    }
-  }
-  return a;
-};
-
-/**
  * Escape the given string of `html`.
  *
  * @param {String} html

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "crc": "0.2.0",
     "cookie": "0.0.3",
     "fresh": "0.0.1",
+    "xtend": "1.0.3",
     "debug": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
Working towards less code duplication in `utils` when suitable modules
are available to perform the required functionality. This makes less
code to maintain in the connect codebase itself and leverages
independently tested modules.
