### PR TITLE
Preventing memory leak if there is pathname mismatch (really fixes #615)

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -209,6 +209,9 @@ function session(options){
     // self-awareness
     if (req.session) return next();
 
+    // pathname mismatch: if the requested url is outside of the cookie path, no session should be created
+    if (0 != req.originalUrl.indexOf(cookie.path)) return next();
+
     // backwards compatibility for signed cookies
     // req.secret is passed from the cookie parser middleware
     var secret = options.secret || req.secret;
@@ -242,9 +245,6 @@ function session(options){
         , tls = req.connection.encrypted || (trustProxy && 'https' == proto)
         , secured = cookie.secure && tls
         , isNew = unsignedCookie != req.sessionID;
-
-      // pathname mismatch
-      if (0 != req.originalUrl.indexOf(cookie.path)) return;
 
       // only send secure cookies via https
       if (cookie.secure && !secured) return debug('not secured');


### PR DESCRIPTION
Hello,

Actually, commit e44351e1140d47f4bb7ba15d0332ddd13f4d999d didn't fix issue #615. In case of pathname mismatch, a new session and corresponding store key was still created, and the cookie not sent. I put the pathname mismatch test at the beginning of the middleware to prevent this memory leak.

Cheers,
Louis
