### PR TITLE
localize favicon cache

### DIFF
--- a/lib/middleware/favicon.js
+++ b/lib/middleware/favicon.js
@@ -13,12 +13,6 @@
 var fs = require('fs')
   , utils = require('../utils');
 
-/*!
- * Favicon cache.
- */
-
-var icon;
-
 /**
  * Favicon:
  *
@@ -56,7 +50,8 @@ var icon;
 module.exports = function favicon(path, options){
   var options = options || {}
     , path = path || __dirname + '/../public/favicon.ico'
-    , maxAge = options.maxAge || 86400000;
+    , maxAge = options.maxAge || 86400000
+    , icon; // favicon cache
 
   return function favicon(req, res, next){
     if ('/favicon.ico' == req.url) {


### PR DESCRIPTION
This change localizes the favicon cache to each invocation of the middleware.  This is useful in cases where one server serves multiple domains, each having it's own favicon.  The way the code is currently written, you only get one favicon cache for the entire process.  With this change, you get one favicon cache for each call to the favicon middleware which allows different connect apps to have a separate favicon cached in memory.
