### PR TITLE
Ignore head options 1.x

### DIFF
--- a/lib/middleware/csrf.js
+++ b/lib/middleware/csrf.js
@@ -77,7 +77,7 @@ module.exports = function csrf(options) {
     var token = req.session._csrf || (req.session._csrf = utils.uid(24));
 
     // ignore GET (for now)
-    if ('GET' == req.method) return next();
+    if ('GET' == req.method || 'HEAD' == req.method || 'OPTIONS' == req.method) return next();
 
     // determine value
     var val = value(req);


### PR DESCRIPTION
These changes are already in connect 2.x, just back-porting them to 1.x
