### PR TITLE
If memory store can gracefully handle connection issues, act as if there is no session

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -209,6 +209,9 @@ function session(options){
     // self-awareness
     if (req.session) return next();
 
+    // Gracefully handle any connection problem: normally serve resources as if nobody is logged in
+    if (store.connectionProblem) {return next();}
+
     // pathname mismatch
     if (0 != req.originalUrl.indexOf(cookie.path || '/')) return next();
 


### PR DESCRIPTION
This is related to https://github.com/visionmedia/connect-redis/pull/50

If we decide to use the "safe mode" in the connect-redis memory store, and there is a connection problem to the memory store, the session middleware should not try to wait for the connection to be reestablished, but rather pass the request to the next middleware, hence making the whole application behave as if there are no sessions whatsoever.

Louis
