### PR TITLE
Fixing cookieSession set-cookie bug

### DIFF
--- a/lib/middleware/cookieSession.js
+++ b/lib/middleware/cookieSession.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - cookieSession
  * Copyright(c) 2011 Sencha Inc.
@@ -84,7 +83,7 @@ module.exports = function cookieSession(options){
       // removed
       if (!req.session) {
         debug('clear session');
-        res.setHeader('Set-Cookie', key + '=; expires=' + new Date(0).toUTCString());
+        res.setHeader('Set-Cookie', key + '=; expires=' + new Date(0).toUTCString() + '; path='+ cookie.path);
         return;
       }
 


### PR DESCRIPTION
In webkit browsers, sending a Set-Cookie header without a path is ignored, so that the next request continues to use the existing cookie. I don't think this is a bug that can be picked up in tests, unfortunately (other than a test for the presence of the 'path' value, which I'd be happy to add)
