### PR TITLE
Fix for #561

### DIFF
--- a/lib/middleware/compress.js
+++ b/lib/middleware/compress.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - compress
  * Copyright(c) 2010 Sencha Inc.
@@ -79,7 +78,7 @@ module.exports = function compress(options) {
     res.write = function(chunk, encoding){
       if (!this.headerSent) this._implicitHeader();
       return stream
-        ? stream.write(chunk, encoding)
+        ? stream.write(new Buffer(chunk, encoding))
         : write.call(res, chunk, encoding);
     };
 


### PR DESCRIPTION
Zlib stream's write method doesn't accept an encoding as an argument. Therefore, create a buffer and pass it to the write method.
