### PR TITLE
Session middleware passes request to next middleware immediately if the session store is not ready

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -206,8 +206,8 @@ function session(options){
     req.session.cookie = new Cookie(cookie);
   };
 
-  store.on('connectionError', function() { storeReady = false; });
-  store.on('connectionEstablished', function() { storeReady = true; });
+  store.on('disconnect', function() { storeReady = false; });
+  store.on('reconnect', function() { storeReady = true; });
 
   return function session(req, res, next) {
     // self-awareness


### PR DESCRIPTION
Related to [PR #54](https://github.com/visionmedia/connect-redis/pull/54) of connect-redis, here is how the session middleware can use the events emitted by RedisStore to avoid, when Redis is down, trying to use a store that cannot work - thus generating very long (~20s) response times.
