### PR TITLE
TypeError: Cannot read property 'secure' of undefined

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -248,7 +248,7 @@ function session(options){
     // set-cookie
     res.on('header', function(){
       if (!req.session) return;
-      var cookie = req.session.cookie
+      var cookie = req.session.cookie || {}
         , proto = (req.headers['x-forwarded-proto'] || '').toLowerCase()
         , tls = req.connection.encrypted || (trustProxy && 'https' == proto)
         , secured = cookie.secure && tls


### PR DESCRIPTION
In some cases, line 254 of `lib/middleware/session.js`:

``` javascript
, secured = cookie.secure && tls
```

was crashing because `cookie` was `undefined`. This is a quick hack to prevent that from happening.

Full stack trace for reference:

```
webkit-devtools-agent: uncaughtException:
TypeError: Cannot read property 'secure' of undefined at ServerResponse.end (/home/node/lib/node_modules/express/node_modules/connect/lib/middleware/session.js:243:27)
at ServerResponse.EventEmitter.emit (events.js:115:20)
at ServerResponse.res.writeHead (/home/node/lib/node_modules/express/node_modules/connect/lib/patch.js:73:36)
at ServerResponse._implicitHeader (http.js:931:8)
at ServerResponse.module.exports.res.write (/home/node/lib/node_modules/express/node_modules/connect/lib/middleware/compress.js:80:34)
at ServerResponse.module.exports.res.end (/home/node/lib/node_modules/express/node_modules/connect/lib/middleware/compress.js:87:23) 
at next (/home/node/lib/node_modules/express/node_modules/connect/lib/proto.js:149:13) 
at next (/home/node/lib/node_modules/express/node_modules/connect/lib/proto.js:195:7)
at store.get.next (/home/node/lib/node_modules/express/node_modules/connect/lib/middleware/session.js:299:9)
at /home/node/lib/node_modules/express/node_modules/connect/lib/middleware/session.js:310:11
```
