### PR TITLE
Support to enable disable middleware during runtime

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -86,7 +86,7 @@ app.use = function(route, fn, name){
   }
 
   // add the middleware
-  name = name ? name : fn.name
+  name = name ? name : fn.name;
   debug('use %s %s', route || '/', name || 'anonymous');
   this.stack.push({ route: route, handle: fn, enabled:true, name: name });
 


### PR DESCRIPTION
Added two attributes ('enabled' and 'name' ) to the middleware object. This can later be used to identify and  enable/disable the middleware, quite handy if some of the middlewares  need to be bypassed 
