### PR TITLE
Add double-gzip checks for compress() middleware.

### DIFF
--- a/lib/middleware/compress.js
+++ b/lib/middleware/compress.js
@@ -25,8 +25,12 @@ exports.methods = {
  */
 
 exports.filter = function(req, res){
-  return /json|text|javascript/.test(res.getHeader('Content-Type'))
-    && res.getHeader('Content-Encoding') !== 'gzip'; // not already gzip-ped
+  var contentType = res.getHeader('Content-Type')
+    , contentEncoding = res.getHeader('Content-Encoding');
+
+  return /json|text|javascript/.test(contentType)
+    && contentEncoding !== 'gzip'
+    && contentEncoding !== 'deflate';
 };
 
 /**


### PR DESCRIPTION
This makes it possible to use the `compress()` middleware with other
middlewares such as `connect-file-cache` which does its own gzip-ing.

Otherwise there is no simple way as of now to detect wether
or not this middleware is used and thus make using/writing/fixing other
middlewares which uses gzip harder/more problematic.

Relying on the module user to get this correct is bad as it is the equivalent
of asking him/her to check all the modules he/she is using for gzip conflict
by try re-ordering several permutations of `app.use` calls in his/her `app.js`
