### PR TITLE
[hotfix]handle ENOTDIR error like ENOENT in static middleware (connect@1.x)

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -146,7 +146,8 @@ var send = exports.send = function(req, res, next, options){
     // ignore ENOENT
     if (err) {
       if (fn) return fn(err);
-      return 'ENOENT' == err.code
+      var notfound = ['ENOENT', 'ENAMETOOLONG', 'ENOTDIR'];
+      return ~notfound.indexOf(err.code)
         ? next()
         : next(err);
     // redirect directory in case index.html is present

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -80,6 +80,12 @@ module.exports = {
       { url: '/foo.json' },
       { body: 'Cannot GET /foo.json', status: 404 });
   },
+
+  'test invalid dir url': function(){
+    assert.response(app,
+      { url: '/user.json/' },
+      { body: 'Cannot GET /user.json/', status: 404 });
+  },
   
   'test directory redirect': function(){
     assert.response(app,


### PR DESCRIPTION
Some people include me are still using connect@1.x in old project.

I think we need to fixed fs.stat error in static middleware.

Handle `ENOTDIR` and `ENAMETOOLONG` just like `ENOENT`.
