### PR TITLE
gracefully handle cookie parsing errors

### DIFF
--- a/lib/middleware/cookieParser.js
+++ b/lib/middleware/cookieParser.js
@@ -54,6 +54,10 @@ module.exports = function cookieParser(secret){
         }
         req.cookies = utils.parseJSONCookies(req.cookies);
       } catch (err) {
+        // cookie parsing results in 400 error
+        // technically malformed cookies are bad requests on the user's part
+        err.status = 400;
+
         return next(err);
       }
     }


### PR DESCRIPTION
Cookie parsing errors should be tagged with 400 status to differentiate
them from other internal errors.
