### PR TITLE
failing multipart test

### DIFF
--- a/test/multipart.js
+++ b/test/multipart.js
@@ -261,7 +261,6 @@ describe('connect.multipart()', function(){
 
       app.use(function(req, res) {
         res.end('whoop');
-        done();
       });
 
       server = http.createServer(app);


### PR DESCRIPTION
(don't merge this)

This is a failing test case for multipart parsing.

See visionmedia/express#1350
