### PR TITLE
Added `defer` property to multipart() middleware

### DIFF
--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -102,7 +102,7 @@ exports = module.exports = function(options){
       });
 
       form.on('error', function(err){
-        if(!options.defer) {
+        if (!options.defer) {
           err.status = 400;
           next(err);
         }
@@ -114,7 +114,7 @@ exports = module.exports = function(options){
         try {
           req.body = qs.parse(data);
           req.files = qs.parse(files);
-          if(!options.defer) next();
+          if (!options.defer) next();
         } catch (err) {
           form.emit('error', err);
         }
@@ -122,7 +122,7 @@ exports = module.exports = function(options){
 
       form.parse(req);
 
-      if(options.defer) {
+      if (options.defer) {
         req.form = form;
         next();
       }

--- a/test/multipart.js
+++ b/test/multipart.js
@@ -266,5 +266,35 @@ describe('connect.multipart()', function(){
       });
     })
 
+    it('should defer processing if `defer` is set', function(done){
+      var app = connect();
+
+      app.use(connect.multipart({"defer": true}));
+
+      app.use(function(req, res){
+        JSON.stringify(req.body).should.equal("{}");
+        req.form.on("end", function() {
+          res.end(JSON.stringify(req.body));
+        });
+      });
+
+      app.request()
+      .post('/')
+      .set('Content-Type', 'multipart/form-data; boundary=foo')
+      .write('--foo\r\n')
+      .write('Content-Disposition: form-data; name="user"\r\n')
+      .write('\r\n')
+      .write('Tobi')
+      .write('\r\n--foo\r\n')
+      .write('Content-Disposition: form-data; name="age"\r\n')
+      .write('\r\n')
+      .write('1')
+      .write('\r\n--foo--')
+      .end(function(res){
+        res.body.should.equal('{"user":"Tobi","age":"1"}');
+        done();
+      });
+    })
+
   })
 })


### PR DESCRIPTION
The newly added `defer` property allows one to defer mulitpart parsing and immediately execute the next middleware. In this case, Formidable's form object is exposed via `req.form`, allowing middleware to bind to "progress", "error", and/or "end" events.

Fixes issue #638
