### PR TITLE
CSRF middleware: expose defaultValue() function

### DIFF
--- a/lib/middleware/csrf.js
+++ b/lib/middleware/csrf.js
@@ -38,7 +38,7 @@ var utils = require('../utils');
 
 module.exports = function csrf(options) {
   var options = options || {}
-    , value = options.value || defaultValue;
+    , value = options.value || exports.defaultValue;
 
   return function(req, res, next){
     // generate CSRF token
@@ -66,7 +66,7 @@ module.exports = function csrf(options) {
  * @api private
  */
 
-function defaultValue(req) {
+exports.defaultValue = function(req) {
   return (req.body && req.body._csrf)
     || (req.query && req.query._csrf)
     || (req.headers['x-csrf-token']);


### PR DESCRIPTION
This makes it convenient to write and provide a custom value() function that can still fall back to the default one.

E.g. during development purposes, I want to ignore CSRF for certain API endpoints. With this, I could achieve that by providing a custom function like:

``` js
connect.csrf({
  value: function (req) {
    if (req.path.indexOf('/foo/bar') === 0) {
      return req.session._csrf;
    } else {
      return connect.csrf.defaultValue(req);
    }
  }
});
```

Thanks. =)
