### PR TITLE
This parameter is not used by this function and not passed in by calls to emit

### DIFF
--- a/lib/middleware/responseTime.js
+++ b/lib/middleware/responseTime.js
@@ -22,7 +22,7 @@ module.exports = function responseTime(){
     if (res._responseTime) return next();
     res._responseTime = true;
 
-    res.on('header', function(header){
+    res.on('header', function(){
       var duration = new Date - start;
       res.setHeader('X-Response-Time', duration + 'ms');
     });


### PR DESCRIPTION
A quick `grep -r "'header'" *` in the `lib/` directory shows that this is a "dead parameter".
