### PR TITLE
log the IP address as seen by Express, if available

### DIFF
--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -299,7 +299,7 @@ exports.token('referrer', function(req){
  */
 
 exports.token('remote-addr', function(req){
-  return req.socket && (req.socket.remoteAddress || (req.socket.socket && req.socket.socket.remoteAddress));
+  return req.ip || req.socket && (req.socket.remoteAddress || (req.socket.socket && req.socket.socket.remoteAddress));
 });
 
 /**


### PR DESCRIPTION
Currently, the `connect.logger` middleware logs the socket’s IP address.

Instead, it should prefer to log `req.ip`—the IP address as seen by Express. This is especially useful when the Express’ “trust proxy” option is enabled. In that case, it will log the _user’s_ IP address, and not the proxy’s IP address.

If not using a proxy, or if `req.ip` is not available (for example, you’re not using Express), it will log the immediate IP address, as before.
