### PR TITLE
Updated comments for logger middleware

### DIFF
--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -66,7 +66,7 @@ var defaultBufferDuration = 1000;
  *      connect.logger({ immediate: true, format: 'dev' })
  *      connect.logger(':method :url - :referrer')
  *      connect.logger(':req[content-type] -> :res[content-type]')
- *      connect.logger(function(exports, req, res){ return 'some format string' })
+ *      connect.logger(function(tokens, req, res){ return 'some format string' })
  *
  * Defining Tokens:
  *


### PR DESCRIPTION
connect.logger(function(req, res){ return 'some format string' }) actually ends up being called with the arguments (exports, req, res). I've updated the comments to match the behavior.
