### PR TITLE
Fix JSON leading whitespaces handling in strict mode.

### DIFF
--- a/lib/middleware/json.js
+++ b/lib/middleware/json.js
@@ -65,7 +65,8 @@ exports = module.exports = function(options){
       req.setEncoding('utf8');
       req.on('data', function(chunk){ buf += chunk });
       req.on('end', function(){
-        if (strict && '{' != buf[0] && '[' != buf[0]) return next(utils.error(400, 'invalid json'));
+        var first = buf.trim()[0];
+        if (strict && '{' != first && '[' != first) return next(utils.error(400, 'invalid json'));
         try {
           req.body = JSON.parse(buf, options.reviver);
           next();

--- a/test/json.js
+++ b/test/json.js
@@ -122,6 +122,25 @@ describe('connect.json()', function(){
         done();
       });
     })
+
+    it('should allow leading whitespaces in JSON', function(done){
+      var app = connect();
+      app.use(connect.json({ strict: true }));
+
+      app.use(function(req, res){
+        res.end(JSON.stringify(req.body));
+      });
+
+      app.request()
+      .post('/')
+      .set('Content-Type', 'application/json')
+      .write('   { "user": "tobi" }')
+      .end(function(res){
+        res.should.have.status(200);
+        res.body.should.include('{"user":"tobi"}');
+        done();
+      });
+    })
   })
 
   describe('by default', function(){


### PR DESCRIPTION
JSON allows leading whitespaces and is considered valid, according
to RFC 4627 http://www.ietf.org/rfc/rfc4627.txt .
