### PR TITLE
Make bodyParser ignore the Content-Type if no body is present

### DIFF
--- a/lib/middleware/json.js
+++ b/lib/middleware/json.js
@@ -50,6 +50,8 @@ exports = module.exports = function(options){
     if (req._body) return next();
     req.body = req.body || {};
 
+    if (!utils.hasBody(req)) return next();
+
     // check Content-Type
     if ('application/json' != utils.mime(req)) return next();
 

--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -61,6 +61,8 @@ exports = module.exports = function(options){
     req.body = req.body || {};
     req.files = req.files || {};
 
+    if (!utils.hasBody(req)) return next();
+
     // ignore GET
     if ('GET' == req.method || 'HEAD' == req.method) return next();
 

--- a/lib/middleware/urlencoded.js
+++ b/lib/middleware/urlencoded.js
@@ -48,6 +48,8 @@ exports = module.exports = function(options){
     if (req._body) return next();
     req.body = req.body || {};
 
+    if (!utils.hasBody(req)) return next();
+
     // check Content-Type
     if ('application/x-www-form-urlencoded' != utils.mime(req)) return next();
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,18 @@ var http = require('http')
   , signature = require('cookie-signature');
 
 /**
+ * Return `true` if the request has a body, otherwise return `false`.
+ *
+ * @param  {IncomingMessage} req
+ * @return {Boolean}
+ * @api private
+ */
+
+exports.hasBody = function(req) {
+  return 'transfer-encoding' in req.headers || 'content-length' in req.headers;
+};
+
+/**
  * Extract the mime type from the given request's
  * _Content-Type_ header.
  *


### PR DESCRIPTION
Add a utils.hasBody(req) function to check for Content-Length or
Transfer-Encoding in the request headers to see if a body exists. Use
this in the middleware to prevent parsing a body in case a client
sends a Content-Type header with no body.
