### PR TITLE
Add a method to remove middleware

### DIFF
--- a/examples/removing-middleware.js
+++ b/examples/removing-middleware.js
@@ -1,0 +1,23 @@
+
+var connect  = require('./')
+  , http = require('http');
+
+// set up connect, add a few middlweware
+var app = connect();
+  app.use(connect.logger('dev'))
+  app.use(connect.bodyParser())
+  app.use(connect.static(__dirname + '/public', { maxAge: 0 }))
+  app.use(connect.cookieParser())
+  app.use(connect.cookieSession({ secret: 'some secret' }));
+
+http.createServer(app).listen(3000);
+
+
+// remove static after a few seconds
+setTimeout(function() {
+
+  console.log('no more static');
+
+  app.unuse(connect.static(__dirname+'/public'), { maxAge: 0}); 
+
+}, 3000);

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -55,11 +55,12 @@ var env = process.env.NODE_ENV || 'development';
  *
  * @param {String|Function|Server} route, callback or server
  * @param {Function|Server} callback or server
+ * @param {Boolean} remove remove the middleware; See also `unuse()`
  * @return {Server} for chaining
  * @api public
  */
 
-app.use = function(route, fn){
+app.use = function(route, fn, remove){
   // default route to '/'
   if ('string' != typeof route) {
     fn = route;
@@ -85,9 +86,38 @@ app.use = function(route, fn){
     route = route.slice(0, -1);
   }
 
-  // add the middleware
-  debug('use %s %s', route || '/', fn.name || 'anonymous');
-  this.stack.push({ route: route, handle: fn });
+  // add or remove the middleware
+  if(remove == true) {
+    for(var i = 0; i < this.stack.length; i++) {
+      var mware = this.stack[i];
+      if(mware.route == route && mware.handle.name == fn.name) // compare on route & name
+      {
+        this.stack.splice(i, 1);
+        debug('removing %s %s', route || '/', fn.name || 'anonymous');
+      }
+    }
+  } else {
+    debug('use %s %s', route || '/', fn.name || 'anonymous');
+    this.stack.push({ route: route, handle: fn });
+  }
+
+  return this;
+};
+
+/**
+ * Removes all middleware at the given 'route' with the given
+ * 'handle'.
+ *
+ * If multiple middleware are used at the same route, all will be removed.
+ *
+ * @param {String|Function|Server} route, callback or server
+ * @param {Function|Server} callback or server
+ * @return {Server} for chaining
+ * @api public
+ */
+app.unuse = function(route, fn) {
+
+  this.use(route, fn, true);
 
   return this;
 };


### PR DESCRIPTION
I came across a situation where I needed to remove middleware after the server has started. Alas, there wasn't any method to do this. 

My use case consists of allowing the changing, adding, removing of Static directories from persistent user settings. Yes, I could write some fancy request handlers to do this, but why reinvent the wheel when the Static middleware does everything I need perfectly? Making middleware more effective > reinventing the wheel, no?

I didn't really know what to name the function so I went with `unuse()`. Add middleware with `use()`, remove it with `unuse()`. 

Also, my preferred method would have been to return an id when you call `use()` so that you can use that to simply remove that specific middleware. That would require some heavy refactoring and would break chaining. Instead, `unuse()` removes all middle of the same type at the same route. I couldn't think of any instances where you would want 
