### PR TITLE
add support for `next(status[, msg])`

### DIFF
--- a/lib/middleware/basicAuth.js
+++ b/lib/middleware/basicAuth.js
@@ -69,13 +69,13 @@ module.exports = function basicAuth(callback, realm) {
 
     var parts = authorization.split(' ');
 
-    if (parts.length !== 2) return next(utils.error(400));
+    if (parts.length !== 2) return next(400);
 
     var scheme = parts[0]
       , credentials = new Buffer(parts[1], 'base64').toString()
       , index = credentials.indexOf(':');
 
-    if ('Basic' != scheme || index < 0) return next(utils.error(400));
+    if ('Basic' != scheme || index < 0) return next(400);
     
     var user = credentials.slice(0, index)
       , pass = credentials.slice(index + 1);

--- a/lib/middleware/csrf.js
+++ b/lib/middleware/csrf.js
@@ -51,7 +51,7 @@ module.exports = function csrf(options) {
     var val = value(req);
 
     // check
-    if (val != token) return next(utils.error(403));
+    if (val != token) return next(403);
     
     next();
   }

--- a/lib/middleware/directory.js
+++ b/lib/middleware/directory.js
@@ -16,7 +16,6 @@
 
 var fs = require('fs')
   , parse = require('url').parse
-  , utils = require('../utils')
   , path = require('path')
   , normalize = path.normalize
   , extname = path.extname
@@ -67,10 +66,10 @@ exports = module.exports = function directory(root, options){
       , showUp = path != root && path != root + '/';
 
     // null byte(s), bad request
-    if (~path.indexOf('\0')) return next(utils.error(400));
+    if (~path.indexOf('\0')) return next(400);
 
     // malicious path, forbidden
-    if (0 != path.indexOf(root)) return next(utils.error(403));
+    if (0 != path.indexOf(root)) return next(403);
 
     // check if we have a directory
     fs.stat(path, function(err, stat){
@@ -96,7 +95,7 @@ exports = module.exports = function directory(root, options){
         }
 
         // not acceptable
-        next(utils.error(406));
+        next(406);
       });
     });
   };

--- a/lib/middleware/json.js
+++ b/lib/middleware/json.js
@@ -68,10 +68,10 @@ exports = module.exports = function(options){
         var first = buf.trim()[0];
 
         if (0 == buf.length) {
-          return next(utils.error(400, 'invalid json, empty body'));
+          return next(400, 'invalid json, empty body');
         }
         
-        if (strict && '{' != first && '[' != first) return next(utils.error(400, 'invalid json'));
+        if (strict && '{' != first && '[' != first) return next(400, 'invalid json');
         try {
           req.body = JSON.parse(buf, options.reviver);
           next();

--- a/lib/middleware/limit.js
+++ b/lib/middleware/limit.js
@@ -42,7 +42,7 @@ module.exports = function limit(bytes){
     req._limit = true;
 
     // limit by content-length
-    if (len && len > bytes) return next(utils.error(413));
+    if (len && len > bytes) return next(413);
 
     // limit
     req.on('data', function(chunk){

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -106,7 +106,7 @@ app.handle = function(req, res, out) {
     , slashAdded = false
     , index = 0;
 
-  function next(err) {
+  function next(err, msg) {
     var layer, path, status, c;
 
     if (slashAdded) {
@@ -117,6 +117,15 @@ app.handle = function(req, res, out) {
     req.url = removed + req.url;
     req.originalUrl = req.originalUrl || req.url;
     removed = '';
+
+    // next(status, msg) support
+    if (typeof err === 'number') {
+      var status = err;
+      var name = http.STATUS_CODES[status];
+      err = new Error(msg || name);
+      err.name = name;
+      err.status = status;
+    }
 
     // next callback
     layer = stack[index++];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,22 +42,6 @@ exports.mime = function(req) {
 };
 
 /**
- * Generate an `Error` from the given status `code`
- * and optional `msg`.
- *
- * @param {Number} code
- * @param {String} msg
- * @return {Error}
- * @api private
- */
-
-exports.error = function(code, msg){
-  var err = new Error(msg || http.STATUS_CODES[code]);
-  err.status = code;
-  return err;
-};
-
-/**
  * Return md5 hash of the given string and optional encoding,
  * defaulting to hex.
  *


### PR DESCRIPTION
When next is called with the first argument as a number, it will be
automatically converted to an Error object with the appropriate status
code.

The motivation behind this change is to make it easier for middleware to
indicate an error has occurred without needing to resort to custom error
classes.

Removes utils.error as it should no longer be used.
