### PR TITLE
Fix directory.html for IE friendly :)

### DIFF
--- a/lib/public/directory.html
+++ b/lib/public/directory.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>listing directory {directory}</title>
@@ -9,8 +10,12 @@
           : id;
 
         el.on = function(event, fn){
-          if ('content loaded' == event) event = 'DOMContentLoaded';
-          el.addEventListener(event, fn, false);
+          if ('content loaded' == event) {
+            event = window.attachEvent ? "load" : "DOMContentLoaded";
+          }
+          el.addEventListener
+            ? el.addEventListener(event, fn, false)
+            : el.attachEvent("on" + event, fn);
         };
 
         el.all = function(selector){


### PR DESCRIPTION
1. The missing DOCTYPE will trigger quirks mode when under IE
2. The IE haven't addEventListener, use attachEvent instead.
