### PR TITLE
Replace 'node-crc' with MIT licensed 'buffer-crc32'

### DIFF
--- a/lib/middleware/cookieSession.js
+++ b/lib/middleware/cookieSession.js
@@ -13,7 +13,7 @@ var utils = require('./../utils')
   , Cookie = require('./session/cookie')
   , debug = require('debug')('connect:cookieSession')
   , signature = require('cookie-signature')
-  , crc16 = require('crc').crc16;
+  , crc32 = require('buffer-crc32');
 
 /**
  * Cookie Session:
@@ -71,7 +71,7 @@ module.exports = function cookieSession(options){
       if (rawCookie) {
         var unsigned = utils.parseSignedCookie(rawCookie, secret);
         if (unsigned) {
-          var originalHash = crc16(unsigned);
+          var originalHash = crc32.signed(unsigned);
           req.session = utils.parseJSONCookie(unsigned) || {};
         }
       }
@@ -101,7 +101,7 @@ module.exports = function cookieSession(options){
       var val = 'j:' + JSON.stringify(req.session);
 
       // compare hashes, no need to set-cookie if unchanged
-      if (originalHash == crc16(val)) return debug('unmodified session');
+      if (originalHash == crc32.signed(val)) return debug('unmodified session');
 
       // set-cookie
       val = 's:' + signature.sign(val, secret);

--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -18,7 +18,7 @@ var Session = require('./session/session')
   , Store = require('./session/store')
   , utils = require('./../utils')
   , parse = utils.parseUrl
-  , crc16 = require('crc').crc16;
+  , crc32 = require('buffer-crc32');
 
 // environment
 
@@ -346,7 +346,7 @@ function session(options){
  */
 
 function hash(sess) {
-  return crc16(JSON.stringify(sess, function(key, val){
+  return crc32.signed(JSON.stringify(sess, function(key, val){
     if ('cookie' != key) return val;
   }));
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "qs": "0.5.1",
     "formidable": "1.0.11",
     "cookie-signature": "0.0.1",
-    "crc": "0.2.0",
+    "buffer-crc32": "0.1.1",
     "cookie": "0.0.5",
     "bytes": "0.0.1",
     "send": "0.1.0",


### PR DESCRIPTION
The 'crc' package is using code that is not freely licensed(MIT/BSD)
https://github.com/alexgorbatchev/node-crc/issues/2

Express also moved to 'buffer-crc32' recently because of this issue.

Fixes senchalabs/connect#712
