### PR TITLE
Include test/support/http.js in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,9 @@ docs/
 examples/
 install.sh
 support/
-test/
-!test/support/http.js
+test/*.js
+test/mocha.opts
+test/shared
+test/fixtures
 .DS_Store
 coverage.html


### PR DESCRIPTION
- To facilitate testing of middleware.

I wanted to be able to, in my middleware's test file,

``` javascript
require('connect/test/support/http'); // For app.request()
```

This allows middleware repos to replicate the test code style of this project.

Would it be cleaner to move the file over to lib/ instead of this change?
