### PR TITLE
Add utf-8 meta tag to support foreign characters in filenames/directorie...

### DIFF
--- a/lib/public/directory.html
+++ b/lib/public/directory.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset='utf-8'> 
     <title>listing directory {directory}</title>
     <style>{style}</style>
     <script>

--- a/lib/public/error.html
+++ b/lib/public/error.html
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta charset='utf-8'> 
     <title>{error}</title>
     <style>{style}</style>
   </head>


### PR DESCRIPTION
Foreign characters are garbled (at least in chrome and firefox), unless utf-8 is specified as a charset.
