### PR TITLE
Response write/end to noop() when request aborted

### DIFF
--- a/lib/middleware/compress.js
+++ b/lib/middleware/compress.js
@@ -73,6 +73,11 @@ module.exports = function compress(options) {
     // vary
     res.setHeader('Vary', 'Accept-Encoding');
 
+    // Remove response write/end if request aborted
+    req.on("close",function() {
+      res.write = res.end = function() {}
+    });
+
     // proxy
 
     res.write = function(chunk, encoding){


### PR DESCRIPTION
Had problems with compress module when the request are aborted by the client:

 ` ` `
Error: Cannot write after end
    at Gzip.write (zlib.js:307:31)
    at ServerResponse.module.exports.res.write (c:\program files\nodejs\node_mo
ules\connect\lib\middleware\compress.js:81:18)
` ` `

I'm not sure if this is the most efficient fix, but pointing res.write and res.end to noop() eliminates the error.
