### PR TITLE
to set the default page of static module

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - static
  * Copyright(c) 2010 Sencha Inc.
@@ -35,6 +34,7 @@ var send = require('send')
  *    - `maxAge`     Browser cache maxAge in milliseconds. defaults to 0
  *    - `hidden`     Allow transfer of hidden files. defaults to false
  *    - `redirect`   Redirect to trailing "/" when the pathname is a dir. defaults to true
+ *    - `index`      Default file name, defaults to 'index.html'
  *
  * @param {String} root
  * @param {Object} options
@@ -77,6 +77,7 @@ exports = module.exports = function static(root, options){
     send(req, path)
       .maxage(options.maxAge || 0)
       .root(root)
+      .index(options.index || 'index.html')
       .hidden(options.hidden)
       .on('error', error)
       .on('directory', directory)


### PR DESCRIPTION
Now we can set the default file to some thing like 'default.htm'. 
The default value is still 'index.html', same as the old version.

example:
    app.use(connect.static('pages', {index:'default.htm'})) ;
