### PR TITLE
Fix htmlPath issue

### DIFF
--- a/lib/middleware/directory.js
+++ b/lib/middleware/directory.js
@@ -154,7 +154,7 @@ function htmlPath(dir) {
   var curr = [];
   return dir.split('/').map(function(part){
     curr.push(part);
-    return '<a href="' + curr.join('/') + '">' + part + '</a>';
+    return part ? '<a href="' + curr.join('/') + '">' + part + '</a>' : '';
   }).join(' / ');
 }
 


### PR DESCRIPTION
Use `/example/` as case.

output:

```
<a href=""></a> / <a href="/example">example</a> / <a href="/example/"></a>
```

Actually, following output more reasonable:

```
/ <a href="/example">example</a> /
```

This pull request fix this issue.
