### PR TITLE
Fix some issues under IE8

### DIFF
--- a/lib/public/directory.html
+++ b/lib/public/directory.html
@@ -19,7 +19,7 @@
             : el.attachEvent("on" + event, fn);
         };
 
-        el.all = function(selector){
+        el.$$ = function(selector){
           return $(el.querySelectorAll(selector));
         };
 
@@ -41,10 +41,15 @@
         };
 
         el.removeClass = function(name){
-          var classes = this.getClasses().filter(function(curr){
-            return curr != name;
-          });
-          this.setAttribute('class', classes);
+          var classes = this.getClasses();
+          var filtered = [];
+          for (var i = 0; i < classes.length; i++) {
+            var curr = classes[i];
+            if (curr != name) {
+              filtered.push(curr);
+            }
+          }
+          this.setAttribute('class', filtered);
         };
 
         return el;
@@ -52,10 +57,10 @@
 
       function search() {
         var str = $('search').value
-          , links = $('files').all('a');
+          , links = $('files').$$('a');
 
         links.each(function(link){
-          var text = link.textContent;
+          var text = link.textContent || link.innerText;
 
           if ('..' == text) return;
           if (str.length && ~text.indexOf(str)) {


### PR DESCRIPTION
The `Element.all` method is available under IE8, and can't be overrided it. `el.all` causes an error under IE8.

I use `el.$$` that inspired by Prototypejs' `$$` instead. It means get a list by selector.

`filter` is only available under ES5, but IE8 isn't.

`textContent` not be supported by IE8, use `innerText` instead.
