### PR TITLE
Fix path delimiters on windows for directory middleware

### DIFF
--- a/lib/middleware/directory.js
+++ b/lib/middleware/directory.js
@@ -174,7 +174,7 @@ function html(files, dir, useIcons) {
     }
 
     return '<li><a href="'
-      + join(dir, file)
+      + dir.replace(/\\/g, '/') + '/' + file
       + '" class="'
       + classes.join(' ') + '"'
       + ' title="' + file + '">'


### PR DESCRIPTION
Chrome manages to hide this problem, but it's an issue when using Firefox.
