### PR TITLE
Name compress middleware

### DIFF
--- a/lib/middleware/compress.js
+++ b/lib/middleware/compress.js
@@ -63,7 +63,7 @@ module.exports = function compress(options) {
   var names = Object.keys(exports.methods)
     , filter = options.filter || exports.filter;
 
-  return function(req, res, next){
+  return function compress(req, res, next){
     var accept = req.headers['accept-encoding']
       , write = res.write
       , end = res.end


### PR DESCRIPTION
Adding a function name makes it easy to see the middleware in `app.stack`
