### PR TITLE
don't accept RegExp grammar in vhost's hostname

### DIFF
--- a/lib/middleware/vhost.js
+++ b/lib/middleware/vhost.js
@@ -8,7 +8,7 @@
 
 /**
  * Vhost:
- * 
+ *
  *   Setup vhost for the given `hostname` and `server`.
  *
  *     connect()
@@ -17,7 +17,7 @@
  *       .use(connect.vhost('*.com', mainApp))
  *
  *  The `server` may be a Connect server or
- *  a regular Node `http.Server`. 
+ *  a regular Node `http.Server`.
  *
  * @param {String} hostname
  * @param {Server} server
@@ -28,7 +28,7 @@
 module.exports = function vhost(hostname, server){
   if (!hostname) throw new Error('vhost hostname required');
   if (!server) throw new Error('vhost server required');
-  var regexp = new RegExp('^' + hostname.replace(/[*]/g, '(.*?)') + '$', 'i');
+  var regexp = new RegExp('^' + hostname.replace(/[^*\w]/g, '\\$&').replace(/[*]/g, '(?:.*?)')  + '$', 'i');
   if (server.onvhost) server.onvhost(hostname);
   return function vhost(req, res, next){
     if (!req.headers.host) return next();

--- a/test/vhost.js
+++ b/test/vhost.js
@@ -61,4 +61,16 @@ describe('connect.vhost()', function(){
     .set('Host', 'ferrets.com')
     .expect(404, done);
   })
+
+  it('should treat dot as a dot', function(done){
+    var app = connect()
+      , tobi = http.createServer(function(req, res){ res.end('tobi') })
+
+    app.use(connect.vhost('a.b.com', tobi));
+
+    app.request()
+    .get('/')
+    .set('Host', 'aXb.com')
+    .expect(404, done);
+  })
 })


### PR DESCRIPTION
There are some side-effects of current implementation of hostname wildcards in vhost middleware. It dynamically creates a RegExp by replacing the star but leaves other special characters intact.

https://github.com/senchalabs/connect/blob/master/lib/middleware/vhost.js#L31

I assume that this behavior is not expected (e.g. "dot" should match "dot", not any character). Escaping all RegExp special characters (or easier - all non-alphanumeric characters) should solve the problem.
