### PR TITLE
[compress] Don't set vary header if already set

### DIFF
--- a/lib/middleware/compress.js
+++ b/lib/middleware/compress.js
@@ -71,7 +71,9 @@ module.exports = function compress(options) {
       , method;
 
     // vary
-    res.setHeader('Vary', 'Accept-Encoding');
+    if (!res.getHeader('Vary')) {
+      res.setHeader('Vary', 'Accept-Encoding');   
+    }
 
     // proxy
 


### PR DESCRIPTION
I set `res.setHeader('Vary', 'Accept, Accept-Encoding')` before compress, and unfortunately I have to reset it again afterwards.
