### PR TITLE
Typo fix in timeout middleware [req->res]

### DIFF
--- a/lib/middleware/timeout.js
+++ b/lib/middleware/timeout.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - timeout
  * Ported from https://github.com/LearnBoost/connect-timeout
@@ -36,7 +35,7 @@ module.exports = function timeout(ms) {
     }, ms);
 
     req.on('timeout', function(){
-      if (req.headerSent) return debug('response started, cannot timeout');
+      if (res.headerSent) return debug('response started, cannot timeout');
       var err = new Error('Response timeout');
       err.timeout = ms;
       err.status = 503;


### PR DESCRIPTION
Discovered this apparent typo while testing the timeout middleware. As far as I can tell "headerSent" is never defined on the ServerRequest object, instead it's on ServerResponse.
