### PR TITLE
logger: Log even when connections are aborted.

### DIFF
--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -135,21 +135,21 @@ exports = module.exports = function logger(options) {
   return function logger(req, res, next) {
     req._startTime = new Date;
 
-    // immediate
-    if (immediate) {
+    function logRequest(){
+      res.removeListener('finish', logRequest);
+      res.removeListener('close', logRequest);
       var line = fmt(exports, req, res);
       if (null == line) return;
       stream.write(line + '\n');
+    };
+
+    // immediate
+    if (immediate) {
+      logRequest();
     // proxy end to output logging
     } else {
-      var end = res.end;
-      res.end = function(chunk, encoding){
-        res.end = end;
-        res.end(chunk, encoding);
-        var line = fmt(exports, req, res);
-        if (null == line) return;
-        stream.write(line + '\n');
-      };
+      res.on('finish', logRequest);
+      res.on('close', logRequest);
     }
 
 
@@ -283,7 +283,7 @@ exports.token('date', function(){
  */
 
 exports.token('status', function(req, res){
-  return res.statusCode;
+  return res.headerSent ? res.statusCode : null;
 });
 
 /**


### PR DESCRIPTION
## Problem

As issue #321 reported, aborted requests haven't been logged by connect's logger middleware.  That issue was closed by the addition of immediate logging, which is a suitable fix for streaming, but isn't the ideal solution for the case where the client aborts the connection.
## Solution

A listener on the 'close' events can be used to log aborted requests.

Since those aborted requests may not have sent the response code (e.g. by calling `response.writeHead(200)`), the status token will return null if res.headerSent isn't true, rather than the default of 200.  This will also fix #378.

I used common function to write the request line to avoid duplicating code with immediate logging.  I used the ['finish' event](http://nodejs.org/api/stream.html#stream_event_finish) as proposed in pull #552 so the function could be reused for both the 'close' and 'finish' events.
