### PR TITLE
Corrected: a 0 length body is a "null" body

### DIFF
--- a/lib/middleware/json.js
+++ b/lib/middleware/json.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - json
  * Copyright(c) 2010 Sencha Inc.
@@ -68,7 +67,8 @@ exports = module.exports = function(options){
         var first = buf.trim()[0];
 
         if (0 == buf.length) {
-          return next(utils.error(400, 'invalid json, empty body'));
+          req.body = null;
+          return next();
         }
         
         if (strict && '{' != first && '[' != first) return next(utils.error(400, 'invalid json'));


### PR DESCRIPTION
Safari may send a content-length: 0 which causes `utils.hasBody` to return true

More detail on my comment on :
https://github.com/senchalabs/connect/issues/415#issuecomment-15553738
