### PR TITLE
Added domains middleware - adds heiarchy of domains and subdomains to request

### DIFF
--- a/lib/middleware/domains.js
+++ b/lib/middleware/domains.js
@@ -1,0 +1,46 @@
+/*!
+ * Connect - domains
+ * Copyright(c) 2013 John Henry
+ * MIT Licensed
+ */
+
+/**
+ * Domains:
+ *
+ * Parse req.headers.host into a heiarchy of domains 
+ * and sub-domains populating the `req.domains` object.
+ *
+ * Examples:
+ *      
+ *     connect()
+ *       .use(connect.domains("test.example.com"))
+ *       .use(function(req, res){
+ *         res.end(JSON.stringify(req.domains));
+ *       });
+ *
+ * @param {Int} level 
+ * // Number of levels beyound which are exclusively within the domain of the application
+ * // Note: as the top level domain must contain at least one token, this will happen at least once, no matter what's specificed
+ * @param {String} level 
+ * // Alternatively, a string may be given as the domain of the application
+ * // Note: This works by matching the number of tokens between dots ("."s). Anything between dots will be ignored.
+ * // Example specifying level as "test.example.com" will work the same as "maps.google.com" or even "..."
+ * // This makes it especially when wanting to match ip addresses as in "127.0.0.1"
+ * @return {Function}
+ * @api public
+ */
+module.exports = function domains(level){
+  return function domains(req, res, next){
+    if (!req.domains) {
+      var level = ((typeof level === 'string')? level.split(".").length : 0) || level || 2;
+      var subdomains = req.headers.host.split(".");
+      var domain = [];
+      do{
+        domain.unshift(subdomains.pop());
+        level--;
+      }while(level>0)
+      req.domains = [domain.join(".")].concat(subdomains.reverse());
+    }
+    next();
+  };
+};


### PR DESCRIPTION
Hello. I've added a new middleware application to Connect called Domains.

It adds an array of domains to the request object as req.domains.

The first item, req.domains[0], is the site domain and is determined by the argument passed into the middleware in the use statement, ie .use(connect.domains("example.com") or .use(connect.domains(2)).

All subsequent items are subdomains

I feel like this would be a welcomed addition to Connect.
