### PR TITLE
session: simplify the conditions used to prevent set-cookie

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -188,7 +188,7 @@ var warning = 'Warning: connection.session() MemoryStore is not\n'
 function session(options){
   var options = options || {}
     , key = options.key || 'connect.sid'
-    , store = options.store || new MemoryStore
+    , store = options.store || new MemoryStore()
     , cookie = options.cookie || {}
     , trustProxy = options.proxy
     , storeReady = true;
@@ -228,8 +228,7 @@ function session(options){
     if (!secret) throw new Error('`secret` option required for sessions');
 
     // parse url
-    var originalHash
-      , originalId;
+    var originalHash;
 
     // expose store
     req.sessionStore = store;
@@ -256,15 +255,19 @@ function session(options){
       // only send secure cookies via https
       if (cookie.secure && !secured) return debug('not secured');
 
-      // long expires, handle expiry server-side
-      if (!isNew && cookie.hasLongExpires) return debug('already set cookie');
-
-      // browser-session length cookie
-      if (null == cookie.expires) {
-        if (!isNew) return debug('already set browser-session cookie');
-      // compare hashes and ids
-      } else if (originalHash == hash(req.session) && originalId == req.session.id) {
-        return debug('unmodified session');
+      if (!isNew) {
+        // long expires, handle expiry server-side
+        if (cookie.hasLongExpires) {
+          return debug('already set cookie');
+        }
+        // browser-session length cookie
+        if (null === cookie.expires) {
+          return debug('already set browser-session cookie');
+        }
+        // compare hashes
+        if (originalHash == hash(req.session)) {
+          return debug('unmodified session');
+        }
       }
 
       var val = 's:' + signature.sign(req.sessionID, secret);
@@ -332,13 +335,12 @@ function session(options){
       } else {
         debug('session found');
         store.createSession(req, sess);
-        originalId = req.sessionID;
         originalHash = hash(sess);
         next();
       }
     });
   };
-};
+}
 
 /**
  * Hash the given `sess` object omitting changes


### PR DESCRIPTION
The `originalId == req.session.id` condition is equivalent to `!isNew`.
So the former is redundant and can be replaced by the latter.

Now the conditions used to prevent set-cookie require `!isNew`, so we can put them under the common condition `!isNew`.

The conditions could be further simplified to something like this:

``` javascript
if (!isNew && (cookie.hasLongExpires
  || null === cookie.expires 
  || originalHash == hash(req.session))) {
  return debug('already set cookie');
}
```
