### PR TITLE
Allow sharing sessions across domains

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -200,7 +200,7 @@ function session(options){
   }
 
   // generates the new session
-  store.generate = function(req){
+  function generateStore(req) {
     req.sessionID = utils.uid(24);
     req.session = new Session(req);
     req.session.cookie = new Cookie(cookie);
@@ -289,7 +289,7 @@ function session(options){
 
     // generate the session
     function generate() {
-      store.generate(req);
+      generateStore(req);
     }
 
     // get the sessionID from the cookie


### PR DESCRIPTION
If you try to share the session store across other application mounted for other domain (ie: sharing the session between domains under the same node instance) 

You can't beacause this in session.js

```
// generates the new session
store.generate = function(req){
  req.sessionID = utils.uid(24);
  req.session = new Session(req);
  req.session.cookie = new Cookie(cookie);
};
```

If you ejecute session() to get the middleware in different applications, the last will override the generate method so something like this won't work in the receiving application: 

```
express.session( { 
  store: sharedSessionStore, 
  cookie: { domain: "otherdomain.com" } 
} );
...
// later on during the request, we clear the cookie 
// so we force to generate a new session
res.clearCookie("connect.sid", { domain: "otherdomain.com" });
// with the passed session id 
req.sessionID = sessionToHijackID;
```

If this provocates security issue, would be nice to have an alternative to deal with the shared sessions.

The fix just keeps the current store.generate functionality in the scope of the execution of sesssion() with a function so the middleware is per application.

This makes the test fail as "store has no method generate".
