### PR TITLE
[limit] use correct encoding for checking length

### DIFF
--- a/lib/middleware/limit.js
+++ b/lib/middleware/limit.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - limit
  * Copyright(c) 2011 TJ Holowaychuk
@@ -46,7 +45,7 @@ module.exports = function limit(bytes){
 
     // limit
     req.on('data', function(chunk){
-      received += chunk.length;
+      received += Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(chunk);
       if (received > bytes) req.destroy();
     });
 


### PR DESCRIPTION
ideally, we should pass the encoding to `Buffer.byteLength`, but I don't know to retrieve it.
