### PR TITLE
use multiparty instead of formidable. closes #673

### DIFF
--- a/lib/middleware/multipart.js
+++ b/lib/middleware/multipart.js
@@ -9,7 +9,7 @@
  * Module dependencies.
  */
 
-var formidable = require('formidable')
+var multiparty = require('multiparty')
   , _limit = require('./limit')
   , utils = require('../utils')
   , qs = require('qs');
@@ -31,7 +31,7 @@ function noop(req, res, next) {
  *
  * Configuration:
  *
- *  The options passed are merged with [formidable](https://github.com/felixge/node-formidable)'s
+ *  The options passed are merged with [multiparty](https://github.com/superjoe30/node-multiparty)'s
  *  `IncomingForm` object, allowing you to configure the upload directory,
  *  size limits, etc. For example if you wish to change the upload dir do the following.
  *
@@ -76,7 +76,7 @@ exports = module.exports = function(options){
     limit(req, res, function(err){
       if (err) return next(err);
 
-      var form = new formidable.IncomingForm
+      var form = new multiparty.Form()
         , data = {}
         , files = {}
         , done;
@@ -111,7 +111,7 @@ exports = module.exports = function(options){
         done = true;
       });
 
-      form.on('end', function(){
+      form.on('close', function(){
         if (done) return;
         try {
           req.body = qs.parse(data);

--- a/package.json
+++ b/package.json
@@ -2,12 +2,18 @@
   "name": "connect",
   "version": "2.7.4",
   "description": "High performance middleware framework",
-  "keywords": ["framework", "web", "middleware", "connect", "rack"],
+  "keywords": [
+    "framework",
+    "web",
+    "middleware",
+    "connect",
+    "rack"
+  ],
   "repository": "git://github.com/senchalabs/connect.git",
   "author": "TJ Holowaychuk <tj@vision-media.ca> (http://tjholowaychuk.com)",
   "dependencies": {
     "qs": "0.5.1",
-    "formidable": "1.0.11",
+    "multiparty": "~2.1.4",
     "cookie-signature": "0.0.1",
     "buffer-crc32": "0.1.1",
     "cookie": "0.0.5",

--- a/test/bodyParser.js
+++ b/test/bodyParser.js
@@ -64,9 +64,9 @@ describe('connect.bodyParser()', function(){
 
       app.use(function(req, res){
         req.body.user.should.eql({ name: 'Tobi' });
-        req.files.text.path.should.not.include('.txt');
-        req.files.text.constructor.name.should.equal('File');
-        res.end(req.files.text.name);
+        req.files.text.path.should.include('.txt');
+        req.files.text.constructor.name.should.equal('Object');
+        res.end(req.files.text.originalFilename);
       });
 
       app.request()
@@ -97,8 +97,8 @@ describe('connect.bodyParser()', function(){
       app.use(function(req, res){
         req.body.user.should.eql({ name: 'Tobi' });
         req.files.text.path.should.include('.txt');
-        req.files.text.constructor.name.should.equal('File');
-        res.end(req.files.text.name);
+        req.files.text.constructor.name.should.equal('Object');
+        res.end(req.files.text.originalFilename);
       });
 
       app.request()
@@ -175,8 +175,8 @@ describe('connect.bodyParser()', function(){
 
       app.use(function(req, res){
         req.files.text.should.have.length(2);
-        req.files.text[0].constructor.name.should.equal('File');
-        req.files.text[1].constructor.name.should.equal('File');
+        req.files.text[0].constructor.name.should.equal('Object');
+        req.files.text[1].constructor.name.should.equal('Object');
         res.end();
       });
 
@@ -205,8 +205,8 @@ describe('connect.bodyParser()', function(){
 
       app.use(function(req, res){
         Object.keys(req.files.docs).should.have.length(2);
-        req.files.docs.foo.name.should.equal('foo.txt');
-        req.files.docs.bar.name.should.equal('bar.txt');
+        req.files.docs.foo.originalFilename.should.equal('foo.txt');
+        req.files.docs.bar.originalFilename.should.equal('bar.txt');
         res.end();
       });
 

--- a/test/multipart.js
+++ b/test/multipart.js
@@ -52,9 +52,9 @@ describe('connect.multipart()', function(){
 
       app.use(function(req, res){
         req.body.user.should.eql({ name: 'Tobi' });
-        req.files.text.path.should.not.include('.txt');
-        req.files.text.constructor.name.should.equal('File');
-        res.end(req.files.text.name);
+        req.files.text.path.should.include('.txt');
+        req.files.text.constructor.name.should.equal('Object');
+        res.end(req.files.text.originalFilename);
       });
 
       app.request()
@@ -85,8 +85,8 @@ describe('connect.multipart()', function(){
       app.use(function(req, res){
         req.body.user.should.eql({ name: 'Tobi' });
         req.files.text.path.should.include('.txt');
-        req.files.text.constructor.name.should.equal('File');
-        res.end(req.files.text.name);
+        req.files.text.constructor.name.should.equal('Object');
+        res.end(req.files.text.originalFilename);
       });
 
       app.request()
@@ -163,8 +163,8 @@ describe('connect.multipart()', function(){
 
       app.use(function(req, res){
         req.files.text.should.have.length(2);
-        req.files.text[0].constructor.name.should.equal('File');
-        req.files.text[1].constructor.name.should.equal('File');
+        req.files.text[0].constructor.name.should.equal('Object');
+        req.files.text[1].constructor.name.should.equal('Object');
         res.end();
       });
 
@@ -193,8 +193,8 @@ describe('connect.multipart()', function(){
 
       app.use(function(req, res){
         Object.keys(req.files.docs).should.have.length(2);
-        req.files.docs.foo.name.should.equal('foo.txt');
-        req.files.docs.bar.name.should.equal('bar.txt');
+        req.files.docs.foo.originalFilename.should.equal('foo.txt');
+        req.files.docs.bar.originalFilename.should.equal('bar.txt');
         res.end();
       });
 
@@ -226,7 +226,7 @@ describe('connect.multipart()', function(){
       });
 
       app.use(function(err, req, res, next){
-        err.message.should.equal('parser error, 16 of 28 bytes parsed');
+        err.message.should.equal('Expected alphabetic character, received 61');
         res.statusCode = err.status;
         res.end('bad request');
       });
@@ -273,7 +273,7 @@ describe('connect.multipart()', function(){
 
       app.use(function(req, res){
         JSON.stringify(req.body).should.equal("{}");
-        req.form.on("end", function() {
+        req.form.on("close", function() {
           res.end(JSON.stringify(req.body));
         });
       });


### PR DESCRIPTION
Breaks backward compatibility. Passes all tests. Adding a backwards compatibility layer would be trivial.
