### PR TITLE
Update buffer-crc32

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "qs": "0.5.1",
     "formidable": "1.0.11",
     "cookie-signature": "1.0.1",
-    "buffer-crc32": "0.1.1",
+    "buffer-crc32": "0.2.1",
     "cookie": "0.0.5",
     "send": "0.1.0",
     "bytes": "0.2.0",


### PR DESCRIPTION
Update buffer-crc32 from 0.1.1 to 0.2.1, AFAICT there are no API changes, all tests pass.

Trivial 1-byte patch is trivial.
