### PR TITLE
drop support for node < v0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "0.6"
   - "0.8"
   - "0.10"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "main": "index",
   "engines": {
-    "node": ">= 0.5.0"
+    "node": ">= 0.8.0"
   },
   "scripts": {
     "test": "make"


### PR DESCRIPTION
formidable dropped support for 0.6, so now the tests are failing.
