### PR TITLE
proto.extend

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - HTTPServer
  * Copyright(c) 2010 Sencha Inc.
@@ -196,6 +195,42 @@ app.handle = function(req, res, out) {
     }
   }
   next();
+};
+
+/**
+ * Gives opportunity to "extend" created application object.
+ *
+ * Examples:
+ *
+ *      var app = connect();
+ *      app.extend(routing()); // brings .get
+ *      app.get('/some/page', somePage);
+ *      app.listen(3000);
+ *
+ *      function routing(options){
+ *        return function(){
+ *          var app = this;         
+ * 
+ *          app.get = function(path, handler){
+ *            app.use(function(req, res, next){
+ *              if (req.method === 'GET' && req.url === path) handler(req, res);
+ *              else next();
+ *            });
+ * 
+ *            return app;
+ *          };
+ *        };
+ *      }
+ *
+ * @param {Function} extension function
+ * @return {Server} for chaining
+ * @api public
+ */
+ 
+app.extend = function(extension){
+  extension.call(this);
+  
+  return this;
 };
 
 /**


### PR DESCRIPTION
Hello. I'm proposing to introduce method .extend.

I'm used express.js, but it too "big" for me and with no needed for me features, I'm using only connect's middlewares. And when I tried to create field named "auth" on express request, I failed.

So, I'm think, that I can just don't use express.js and use pure connect.js.

But only middlewares it is not many as needed. And I propose to add "extensions". They just will get connect() object as this and add different functionalities.

In code I'm created very small and non-profit example. [Here](https://gist.github.com/Rulexec/5475181) is more powerful extension (routing too).

Yes, I can just pass connect() object to my function and modify it in it, but it's not chainable good. Also, I can just in every my new project write:

``` javascript
var app = connect();
connect.extend = function(extension) {
    return extension.call(this), this;
};
```

But it's not very good too.

// Sorry for grammar, I'm working on this.

Thanks!
