### PR TITLE
hasBody() should return false if Content-Length: 0

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - utils
  * Copyright(c) 2010 Sencha Inc.
@@ -29,7 +28,7 @@ exports.brokenPause = parseInt(nodeVersion[0], 10) === 0
  */
 
 exports.hasBody = function(req) {
-  return 'transfer-encoding' in req.headers || 'content-length' in req.headers;
+  return 'transfer-encoding' in req.headers || ('content-length' in req.headers && req.headers["content-length"] !== "0");;
 };
 
 /**


### PR DESCRIPTION
Some clients will set Content-Length: 0 when there is no content (and shouldn't be, e.g. on a GET). This can cause other parts of connect to be confused. For instance, if the client also sets Content-Type: application/json, the json middleware will try to parse an empty string and blow up.

Of course, such clients are unhelpful at best, but connect should not blow up.
