### PR TITLE
cookie session: add support for multiple x-forwarded-proto values

### DIFF
--- a/lib/middleware/cookieSession.js
+++ b/lib/middleware/cookieSession.js
@@ -92,7 +92,7 @@ module.exports = function cookieSession(options){
 
       // check security
       var proto = (req.headers['x-forwarded-proto'] || '').toLowerCase()
-        , tls = req.connection.encrypted || (trustProxy && 'https' == proto)
+        , tls = req.connection.encrypted || (trustProxy && 'https' == proto.split(/\s*,\s*/)[0])
         , secured = cookie.secure && tls;
 
       // only send secure cookies via https

--- a/test/cookieSession.js
+++ b/test/cookieSession.js
@@ -349,7 +349,7 @@ describe('connect.cookieSession()', function(){
           .use(connect.cookieParser())
           .use(connect.cookieSession({ secret: 'keyboard cat', proxy: true, cookie: { secure: true }}))
           .use(respond);
-  
+
         app.request()
         .get('/')
         .set('X-Forwarded-Proto', 'https')
@@ -358,15 +358,45 @@ describe('connect.cookieSession()', function(){
           done();
         });
       })
+
+      it('should trust X-Forwarded-Proto when initial proxy is https', function(done){
+        var app = connect()
+          .use(connect.cookieParser())
+          .use(connect.cookieSession({ secret: 'keyboard cat', proxy: true, cookie: { secure: true }}))
+          .use(respond);
+
+        app.request()
+        .get('/')
+        .set('X-Forwarded-Proto', 'https, http')
+        .end(function(res){
+          res.headers.should.have.property('set-cookie');
+          done();
+        });
+      })
+
+      it('should not trust X-Forwarded-Proto when initial proxy is not https', function(done){
+        var app = connect()
+          .use(connect.cookieParser())
+          .use(connect.cookieSession({ secret: 'keyboard cat', proxy: true, cookie: { secure: true }}))
+          .use(respond);
+
+        app.request()
+        .get('/')
+        .set('X-Forwarded-Proto', 'http, https')
+        .end(function(res){
+          res.headers.should.not.have.property('set-cookie');
+          done();
+        });
+      })
     })
-  
+
     describe('when disabled', function(){
       it('should not trust X-Forwarded-Proto', function(done){
         var app = connect()
           .use(connect.cookieParser())
           .use(connect.cookieSession({ secret: 'keyboard cat', cookie: { secure: true }}))
           .use(respond);
-  
+
         app.request()
         .get('/')
         .set('X-Forwarded-Proto', 'https')


### PR DESCRIPTION
related to visionmedia/express#1646
basically copied from https://github.com/visionmedia/express/commit/8ab44081d4a6812e6dc790bbc2f9305f9d88eff4
