### PR TITLE
lazy sessions feature

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -191,6 +191,7 @@ function session(options){
     , store = options.store || new MemoryStore
     , cookie = options.cookie || {}
     , trustProxy = options.proxy
+    , emptyFn = options.emptyFn || function (session) { return false }
     , storeReady = true;
 
   // notify user that this store is not
@@ -244,6 +245,19 @@ function session(options){
       unsignedCookie = utils.parseSignedCookie(rawCookie, secret);
     }
 
+    // lazy sessions flag
+    var isEmpty;
+
+    function sendCookie () {
+      var val = '';
+      if (!isEmpty) {
+        val = 's:' + signature.sign(req.sessionID, secret);
+      }
+      val = req.session.cookie.serialize(key, val);
+      debug('set-cookie %s', val);
+      res.setHeader('Set-Cookie', val);
+    }
+
     // set-cookie
     res.on('header', function(){
       if (!req.session) return;
@@ -253,24 +267,36 @@ function session(options){
         , secured = cookie.secure && tls
         , isNew = unsignedCookie != req.sessionID;
 
-      // only send secure cookies via https
-      if (cookie.secure && !secured) return debug('not secured');
+      isEmpty = emptyFn(req.session);
+      if (isEmpty) {
+        if (isNew) {
+          debug('new session is empty, deleting!');
+          // a session starts out empty, avoid setting cookie.
+          return;
+        }
+        else {
+          debug('deleting session that has become empty!');
+          // a session has become empty, try to expire the cookie.
+          cookie.expires = new Date(0);
+        }
+      }
+      else {
+        // only send secure cookies via https
+        if (cookie.secure && !secured) return debug('not secured');
 
-      // long expires, handle expiry server-side
-      if (!isNew && cookie.hasLongExpires) return debug('already set cookie');
+        // long expires, handle expiry server-side
+        if (!isNew && cookie.hasLongExpires) return debug('already set cookie');
 
-      // browser-session length cookie
-      if (null == cookie.expires) {
-        if (!isNew) return debug('already set browser-session cookie');
-      // compare hashes and ids
-      } else if (originalHash == hash(req.session) && originalId == req.session.id) {
-        return debug('unmodified session');
+        // browser-session length cookie
+        if (null == cookie.expires) {
+          if (!isNew) return debug('already set browser-session cookie');
+        // compare hashes and ids
+        } else if (originalHash == hash(req.session) && originalId == req.session.id) {
+          return debug('unmodified session');
+        }
       }
 
-      var val = 's:' + signature.sign(req.sessionID, secret);
-      val = cookie.serialize(key, val);
-      debug('set-cookie %s', val);
-      res.setHeader('Set-Cookie', val);
+      sendCookie();
     });
 
     // proxy end() to commit the session
@@ -278,13 +304,30 @@ function session(options){
     res.end = function(data, encoding){
       res.end = end;
       if (!req.session) return res.end(data, encoding);
-      debug('saving');
-      req.session.resetMaxAge();
-      req.session.save(function(err){
-        if (err) console.error(err.stack);
-        debug('saved');
-        res.end(data, encoding);
-      });
+      var isNew = unsignedCookie != req.sessionID;
+      if (typeof isEmpty === 'undefined') isEmpty = emptyFn(req.session);
+      if (isEmpty) {
+        // don't save new empty session
+        if (isNew) return res.end(data, encoding);
+        // destroy old empty session
+        if (!res._emittedHeader) {
+          req.session.cookie.expires = new Date(0);
+          sendCookie();
+        }
+        req.session.destroy(function (err) {
+          if (err) console.error(err.stack);
+          res.end(data, encoding);
+        });
+      }
+      else {
+        debug('saving');
+        req.session.resetMaxAge();
+        req.session.save(function(err){
+          if (err) console.error(err.stack);
+          debug('saved');
+          res.end(data, encoding);
+        });
+      }
     };
 
     // generate the session


### PR DESCRIPTION
By passing an `emptyFn` option to `connect.session()`, which should return `true` if the session is considered empty, here's a way to avoid maintaining empty sessions and the corresponding `set-cookie` in responses.

This is needed for reverse-proxy caching where a `set-cookie` in a response defeats cache-ability. Also nice for performance reasons, i.e. a lightweight JSON endpoint that shouldn't be creating a session every time it's hit.
