### PR TITLE
Don't use octal escape sequences as they cause syntax errors in strict mode

### DIFF
--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -237,13 +237,13 @@ exports.format('dev', function(tokens, req, res){
     ? ''
     : len = ' - ' + bytes(len);
 
-  return '\033[90m' + req.method
+  return '\x1b[90m' + req.method
     + ' ' + req.originalUrl + ' '
-    + '\033[' + color + 'm' + res.statusCode
-    + ' \033[90m'
+    + '\x1b[' + color + 'm' + res.statusCode
+    + ' \x1b[90m'
     + (new Date - req._startTime)
     + 'ms' + len
-    + '\033[0m';
+    + '\x1b[0m';
 });
 
 /**


### PR DESCRIPTION
Currently, attempting to run an application that depends upon this module in global strict mode (via the --use-strict flag) fails, due to the use of octal escape sequences (used to produce coloured output).

Octal escape sequences are deprecated in ES5 and cause a syntax error in strict mode. Changing the octal sequences to be hex escapes fixes the problem, and should work in all shells that support the octal syntax for colours.
