### PR TITLE
Flexible json content type

### DIFF
--- a/lib/middleware/json.js
+++ b/lib/middleware/json.js
@@ -11,12 +11,7 @@
  */
 
 var utils = require('../utils')
-  , _limit = require('./limit')
-  // Default JSON mime type regular expression is a case insensitive match of
-  //    application/json
-  // or, with suffix notation
-  //    application/vnd.your.possibly.weird._!#$%*`-^~-name.here+json
-  , defaultMimeRegExp = /^application\/([\w!#\$%&\*`\-\.\^~]*\+)?json$/i;
+  , _limit = require('./limit');
 
 /**
  * noop middleware.
@@ -45,8 +40,7 @@ function noop(req, res, next) {
 
 exports = module.exports = function(options){
   var options = options || {}
-    , strict = options.strict !== false
-    , mimeRegExp = options.mimeRegExp || defaultMimeRegExp;
+    , strict = options.strict !== false;
 
   var limit = options.limit
     ? _limit(options.limit)
@@ -59,7 +53,7 @@ exports = module.exports = function(options){
     if (!utils.hasBody(req)) return next();
 
     // check Content-Type
-    if (!mimeRegExp.test(utils.mime(req))) return next();
+    if (!exports.regexp.test(utils.mime(req))) return next();
 
     // flag as parsed
     req._body = true;
@@ -91,4 +85,5 @@ exports = module.exports = function(options){
   };
 };
 
-exports.defaultMimeRegExp = defaultMimeRegExp;
+exports.regexp = /^application\/([\w!#\$%&\*`\-\.\^~]*\+)?json$/i;
+

--- a/test/json.js
+++ b/test/json.js
@@ -181,40 +181,44 @@ describe('connect.json()', function(){
   })
 
   describe('the default json mime type regular expression', function() {
-    var mimeRegExp = connect.json.defaultMimeRegExp;
+    var mimeRegExp = connect.json.regexp;
     it('should support the basic JSON mime type', function(){
       mimeRegExp.test('application/json').should.eql(true);
     })
+
     it('should not match incorrect mime type', function(){
       mimeRegExp.test('zapplication/json').should.eql(false);
     })
+
     it('should be case insensitive', function(){
       mimeRegExp.test('Application/JSON').should.eql(true);
     })
+
     it('should support suffix notation', function(){
       mimeRegExp.test('application/vnd.organization.prog-type.org+json').should.eql(true);
     })
+
     it('should support specific special characters on mime subtype', function(){
       mimeRegExp.test('application/vnd.organization.special_!#$%*`-^~.org+json').should.eql(true);
     })
+
     it('should not support other special characters on mime subtype', function(){
       mimeRegExp.test('application/vnd.organization.special_()<>@,;:\\"/[]?={} \t.org+json').should.eql(false);
     })
+
     it('should not match malformed mime subtype suffix', function(){
       mimeRegExp.test('application/vnd.test.org+json+xml').should.eql(false);
     })
-    it('should be overridable', function(done){
-      var customApp = connect();
-      customApp.use(connect.json({ mimeRegExp: /application\/custom/ }));
-      customApp.use(function(req, res){
-        res.end(JSON.stringify(req.body));
-      });
 
-      customApp.request()
+    it('should be overridable', function(done){
+      var defaultRegExp = connect.json.regexp;
+      connect.json.regexp = /application\/custom/;
+      app.request()
       .post('/')
       .set('Content-Type', 'application/custom')
       .write('{"user":"tobi"}')
       .end(function(res){
+        connect.json.regexp = defaultRegExp;
         res.body.should.equal('{"user":"tobi"}');
         done();
       });


### PR DESCRIPTION
JSON body parser now has:

. MIME type matching through a regular expression rather than using a string comparison with 'application/json'.
. A default MIME type regular expression that performs a case-insensitive match on MIME types.
. A default MIME type regular expression that also matches suffixes, as in 'application/vnd.acme.data.com+json'.
. A way to access the JSON body parser's default regular expression through connect.json.defaultMimeRegExp.
. A way to override the default regular expression through the options.mimeRegExp.

This is to support MIME types that have suffixes as described here:

   http://trac.tools.ietf.org/html/draft-ietf-appsawg-media-type-suffix-regs-02#section-3.1

Tests were added to validate all the above claims.
