### PR TITLE
Added ability provide a filter function

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -79,6 +79,7 @@ exports = module.exports = function(root, options){
       .root(root)
       .index(options.index || 'index.html')
       .hidden(options.hidden)
+      .filter(options.filter)
       .on('error', error)
       .on('directory', directory)
       .pipe(res);


### PR DESCRIPTION
Let's say you didn't want to server a certain folder or type of file that you store in the public folder. This allows you to pass a callback that is just a more general version of the hidden filter.

Example to serve all files in a folder named 'public' except for text files:

```
app.use('/', express.static('public/', { filter: function (filename) { return filename.match(/\.txt/) } }))
```

I'm submitting a complementary patch to Send as well.
