### PR TITLE
Vary header was being set before filter and other checks were made

### DIFF
--- a/lib/middleware/compress.js
+++ b/lib/middleware/compress.js
@@ -126,6 +126,14 @@ module.exports = function compress(options) {
       // default request filter
       if (!filter(req, res)) return;
 
+      // vary
+      var vary = res.getHeader('Vary');
+      if (!vary) {
+        res.setHeader('Vary', 'Accept-Encoding');
+      } else if (!~vary.indexOf('Accept-Encoding')) {
+        res.setHeader('Vary', vary + ', Accept-Encoding');
+      }
+
       // SHOULD use identity
       if (!accept) return;
 
@@ -155,16 +163,7 @@ module.exports = function compress(options) {
       res.setHeader('Content-Encoding', method);
       res.removeHeader('Content-Length');
 
-      // vary
-      var vary = res.getHeader('Vary');
-      if (!vary) {
-        res.setHeader('Vary', 'Accept-Encoding');
-      } else if (!~vary.indexOf('Accept-Encoding')) {
-        res.setHeader('Vary', vary + ', Accept-Encoding');
-      }
-
       // compression
-
       stream.on('data', function(chunk){
         write.call(res, chunk);
       });


### PR DESCRIPTION
I created an issue #848 about this. This moves the setting of the Vary header to after all of the checks are done to decide if we are actually going to compress this response.
