### PR TITLE
MomentJS for date formatting option in logger

### DIFF
--- a/examples/logger.format.js
+++ b/examples/logger.format.js
@@ -55,8 +55,17 @@ connect()
   })
   .listen(3001);
 
+
+// custom date format string
+
+connect()
+  .use(connect.logger({
+    format: ':date[DD/MMM/YYYY:HH:mm:ss] :method :url - :res[content-type]'
+  }))
+  .listen(3002);
+
 // pre-defined
 
 connect()
   .use(connect.logger('short'))
-  .listen(3002);
+  .listen(3003);

--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -9,7 +9,8 @@
  * Module dependencies.
  */
 
-var bytes = require('bytes');
+var bytes = require('bytes'),
+  moment = require('moment');
 
 /*!
  * Log buffer.
@@ -271,10 +272,15 @@ exports.token('response-time', function(req){
 });
 
 /**
- * UTC date
+ * Date
+ *    either a formatted Moment Date
+ *    or a UTC Date
  */
 
-exports.token('date', function(){
+exports.token('date', function(req, res, dateFormat){
+  if (dateFormat !== 'undefined') {
+    return moment().format(dateFormat);
+  }
   return new Date().toUTCString();
 });
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "pause": "0.0.1",
     "uid2": "0.0.2",
     "debug": "*",
-    "methods": "0.0.1"
+    "methods": "0.0.1",
+    "moment": "2.1.0"
   },
   "devDependencies": {
     "should": "*",


### PR DESCRIPTION
Adding the MomentJS module to Logger will allow more fine grained control of the Logger's log format by providing an option to format the ":date" as seen in the Logger's format string.

This is my proposal for Issue #856.
