### PR TITLE
Expose the compress instance on the response.

### DIFF
--- a/lib/middleware/compress.js
+++ b/lib/middleware/compress.js
@@ -157,7 +157,7 @@ module.exports = function compress(options) {
       if (!method) return;
 
       // compression stream
-      stream = exports.methods[method](options);
+      res.compressor = stream = exports.methods[method](options);
 
       // header fields
       res.setHeader('Content-Encoding', method);


### PR DESCRIPTION
This is necessary to allow clients to call `res.compressor.flush`.  Without this, zlib will buffer responses, preventing `res.write` from immediately serving a chunk to the client.
