### PR TITLE
Compress SVG and common font files by default.

### DIFF
--- a/lib/middleware/compress.js
+++ b/lib/middleware/compress.js
@@ -26,7 +26,7 @@ exports.methods = {
  */
 
 exports.filter = function(req, res){
-  return /json|text|javascript|dart/.test(res.getHeader('Content-Type'));
+  return /json|text|javascript|dart|image\/svg\+xml|application\/x-font-ttf|application\/vnd\.ms-opentype|application\/vnd\.ms-fontobject/.test(res.getHeader('Content-Type'));
 };
 
 /**


### PR DESCRIPTION
Sets the default compression filter to also include svg, ttf, otf, and
eot files, as these are commonly used and can be compressed.

SVG is entirely text (xml), and these three font formats are also primarily text, and nicely compressible.
WOFF files are already compressed and don't need to be included.

I began looking into this when google's [pagespeed insights](https://developers.google.com/speed/pagespeed/insights/) analyzer was telling me to gzip my svg logos even when I already had express.compress() correctly turned on.

Turns out tests have been done on this in the past and all of these file types can be compressed with an average of over 40% savings. (With some svg's seeing much higher savings.) (http://www.phpied.com/gzip-your-font-face-files/)

If the pull is acceptable, let me know and I'll sign the CLA.
