### PR TITLE
use Date.now() instead of new Date() on responseTime middleware

### DIFF
--- a/lib/middleware/responseTime.js
+++ b/lib/middleware/responseTime.js
@@ -17,13 +17,13 @@
 
 module.exports = function responseTime(){
   return function(req, res, next){
-    var start = new Date;
+    var start = Date.now();
 
     if (res._responseTime) return next();
     res._responseTime = true;
 
     res.on('header', function(){
-      var duration = new Date - start;
+      var duration = Date.now() - start;
       res.setHeader('X-Response-Time', duration + 'ms');
     });
 


### PR DESCRIPTION
`Date.now()` is 2X faster than `new Date()`:

``` bash
Date.now() x 8,889,858 ops/sec ±1.34% (94 runs sampled)
Date.now() - Date.now() x 4,379,721 ops/sec ±1.04% (92 runs sampled)
Date.now() - startNow x 7,886,918 ops/sec ±2.01% (96 runs sampled)
new Date() x 4,433,139 ops/sec ±1.99% (94 runs sampled)
new Date() - new Date() x 1,508,084 ops/sec ±2.27% (93 runs sampled)
new Date() - start x 2,169,245 ops/sec ±1.74% (90 runs sampled)
```
