### PR TITLE
Getter property redefinition bug: "req.session._csrf"

### DIFF
--- a/lib/middleware/csrf.js
+++ b/lib/middleware/csrf.js
@@ -75,6 +75,7 @@ module.exports = function csrf(options) {
       // compatibility with old middleware
       delete req.session._csrf;
       Object.defineProperty(req.session, '_csrf', {
+        configurable: true,
         get: function() {
           console.warn('req.session._csrf is deprecated, use req.csrfToken([callback]) instead');
           return req.csrfToken();


### PR DESCRIPTION
The line `delete req.session._csrf;` in `lib/middleware/csrf.js` does not actually delete pre-defined property as `_csrf` is a non-configurable property defined by `Object.defineProperty`. As a result, property redefinition error occurs when the inner function `createToken()` is called the second time.

This PR fixes the bug by setting `configurable` attribute to descriptor during property creation, as advised in [Mozilla Doc - Object.defineProperty: Modifying a property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#Modifying_a_property):

<blockquote>
When the property already exists, Object.defineProperty() attempts to modify the property according to the values in the descriptor and the object's current configuration. If the old descriptor had its configurable attribute set to false (the property is said to be "non-configurable"), then no attribute besides writable can be changed. In that case, it is also not possible to switch back and forth between the data and accessor property types.

If a property is non-configurable, its writable attribute can only be changed to false.

A TypeError is thrown when attempts are made to change non-configurable property attributes (besides the writable attribute) unless the current and new values are the same.
</blockquote>
