### PR TITLE
csrf: fix typo (enumerabe -> enumerable)

### DIFF
--- a/lib/middleware/csrf.js
+++ b/lib/middleware/csrf.js
@@ -74,7 +74,7 @@ module.exports = function csrf(options) {
       
       // compatibility with old middleware
       Object.defineProperty(req.session, '_csrf', {
-        enumerabe: false,
+        enumerable: false,
         configurable: true,
         get: function() {
           console.warn('req.session._csrf is deprecated, use req.csrfToken([callback]) instead');


### PR DESCRIPTION
[Mozilla Doc: Object.defineProperty](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#Description)

@visionmedia 
