### PR TITLE
Remove async version of csrfToken() & use a fast non-blocking PRNG

### DIFF
--- a/lib/middleware/csrf.js
+++ b/lib/middleware/csrf.js
@@ -59,17 +59,8 @@ module.exports = function csrf(options) {
       var token;
 
       // lazy-load token
-      req.csrfToken = function(fn){
-        if (fn) {
-          if (token) return fn(null, token);
-          saltedToken(secret, function(err, tok){
-            token = tok;
-            fn(err, tok);
-          });
-          return;
-        }
-
-        return token || (token = saltedTokenSync(secret));
+      req.csrfToken = function csrfToken() {
+        return token || (token = saltedToken(secret));
       };
       
       // compatibility with old middleware
@@ -113,30 +104,15 @@ function defaultValue(req) {
 }
 
 /**
- * Async salted token.
- *
- * @param {String} secret
- * @param {Function} fn
- * @api private
- */
-
-function saltedToken(secret, fn) {
-  uid(10, function(err, salt){
-    if (err) return fn(err);
-    fn(null, createToken(salt, secret));
-  });
-}
-
-/**
- * Return sync salted token.
+ * Return salted token.
  *
  * @param {String} secret
  * @return {String}
  * @api private
  */
 
-function saltedTokenSync(secret) {
-  return createToken(uid(10), secret);
+function saltedToken(secret) {
+  return createToken(generateSalt(10), secret);
 }
 
 /**
@@ -168,3 +144,21 @@ function checkToken(token, secret) {
   if ('string' != typeof token) return false;
   return token === createToken(token.slice(0, 10), secret);
 }
+
+/**
+ * Generates a random salt, using a fast non-blocking PRNG (Math.random()).
+ *
+ * @param {Number} length
+ * @return {String}
+ * @api private
+ */
+
+function generateSalt(length) {
+  var i, r = [];
+  for (i = 0; i < length; ++i) {
+    r.push(SALTCHARS[Math.floor(Math.random() * SALTCHARS.length)]);
+  }
+  return r.join('');
+}
+
+var SALTCHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';


### PR DESCRIPTION
As discussed in #881: Removed async version of csrfToken(). Used Math.random() as PRNG for the salt generation (which removes the need for async).
