### PR TITLE
no deprecation warning when JSON.stringifying session

### DIFF
--- a/lib/middleware/csrf.js
+++ b/lib/middleware/csrf.js
@@ -66,6 +66,7 @@ module.exports = function csrf(options) {
       // compatibility with old middleware
       Object.defineProperty(req.session, '_csrf', {
         configurable: true,
+        enumerable: false,
         get: function() {
           console.warn('req.session._csrf is deprecated, use req.csrfToken() instead');
           return req.csrfToken();


### PR DESCRIPTION
I'm getting extreme numbers of deprecation warnings from the session middleware's JSON.stringification of req.session. This change removes the _csrf property (only there for deprecation warnings) from that listing.
