### PR TITLE
Allow middleware after response has been sent

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -122,37 +122,43 @@ app.handle = function(req, res, out) {
     layer = stack[index++];
 
     // all done
-    if (!layer || res.headerSent) {
+    if (!layer) {
       // delegate to parent
       if (out) return out(err);
 
       // unhandled error
       if (err) {
-        // default to 500
-        if (res.statusCode < 400) res.statusCode = 500;
-        debug('default %s', res.statusCode);
-
-        // respect err.status
-        if (err.status) res.statusCode = err.status;
-
-        // production gets a basic error message
-        var msg = 'production' == env
-          ? http.STATUS_CODES[res.statusCode]
-          : err.stack || err.toString();
-
-        // log to stderr in a non-test env
+      	// log to stderr in a non-test env
         if ('test' != env) console.error(err.stack || err.toString());
-        if (res.headerSent) return req.socket.destroy();
-        res.setHeader('Content-Type', 'text/plain');
-        res.setHeader('Content-Length', Buffer.byteLength(msg));
-        if ('HEAD' == req.method) return res.end();
-        res.end(msg);
+        
+        if (res.headerSent) {
+          return req.socket.destroy();
+        } else {
+          // default to 500
+          if (res.statusCode < 400) res.statusCode = 500;
+          debug('default %s', res.statusCode);
+
+          // respect err.status
+          if (err.status) res.statusCode = err.status;
+
+          // production gets a basic error message
+          var msg = 'production' == env
+            ? http.STATUS_CODES[res.statusCode]
+            : err.stack || err.toString();
+
+          res.setHeader('Content-Type', 'text/plain');
+          res.setHeader('Content-Length', Buffer.byteLength(msg));
+          if ('HEAD' == req.method) return res.end();
+          res.end(msg);
+        }
       } else {
-        debug('default 404');
-        res.statusCode = 404;
-        res.setHeader('Content-Type', 'text/plain');
-        if ('HEAD' == req.method) return res.end();
-        res.end('Cannot ' + utils.escape(req.method) + ' ' + utils.escape(req.originalUrl));
+      	if (!res.headerSent) {
+          debug('default 404');
+          res.statusCode = 404;
+          res.setHeader('Content-Type', 'text/plain');
+          if ('HEAD' == req.method) return res.end();
+          res.end('Cannot ' + utils.escape(req.method) + ' ' + utils.escape(req.originalUrl));
+        }
       }
       return;
     }

--- a/test/app.listen.js
+++ b/test/app.listen.js
@@ -5,8 +5,9 @@ describe('app.listen()', function(){
   it('should wrap in an http.Server', function(done){
     var app = connect();
 
-    app.use(function(req, res){
+    app.use(function(req, res, next){
       res.end();
+      next();
     });
 
     app.listen(5555, function(){


### PR DESCRIPTION
For doing post-response processing, this seems useful since it allows easier separation of concern (see example below).

If not merged, would you have an idea on how to better solve this? Seems like it's actually an issue noted in the commit that added the check for sent headers: https://github.com/senchalabs/connect/commit/91edd0bac49a4ace1c9ad373c13617a2aaad2772

Not sure if this breaks BC. I don't think so, since it should _only_ allow to call `next()` after a response has been ended whereas before, calling `next()` would throw.

Example use case would be something like this:

``` javascript
var app = connect();

app.use(router);

app.use(function(req, res, next) {
    console.log('More things to do for each request/response.');
});
```
