### PR TITLE
Add option to prevent generating new sessions

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -69,13 +69,26 @@ var warning = 'Warning: connection.session() MemoryStore is not\n'
  *   - `secret` session cookie is signed with this secret to prevent tampering
  *   - `cookie` session cookie settings, defaulting to `{ path: '/', httpOnly: true, maxAge: null }`
  *   - `proxy` trust the reverse proxy when setting secure cookies (via "x-forwarded-proto")
- *   - `generate` set to false to only read session data, without creating a new session if one does not yet exist
+ *   - `generate` pass in a function to control session generation
  *
  * Cookie option:
  *
  *  By default `cookie.maxAge` is `null`, meaning no "expires" parameter is set
  *  so the cookie becomes a browser-session cookie. When the user closes the
  *  browser the cookie (and session) will be removed.
+ *
+ * Generate option:
+ *
+ *  By default, the middleware will generate a new session whenever it is inserted in the request
+ *  chain and no session has yet been found in the request. `options.generate` takes an optional
+ *  function which can provide finer-grained control over when sessions are created. If the
+ *  passed function returns false, any existing session data will be parsed and placed in the
+ *  request object, but a new session will not be created if one does not yet exist.
+ *
+ *      generate: function(req, res) {
+ *         return req.url === '/create-session' || req.url === '/login' || req.url === '/register'
+ *      }
+ *
  *
  * ## req.session
  *
@@ -193,7 +206,7 @@ function session(options){
     , cookie = options.cookie || {}
     , trustProxy = options.proxy
     , storeReady = true
-    , generateSession = (options.generate !== false);
+    , generateSession = options.generate || function() { return true };
 
   // notify user that this store is not
   // meant for a production environment
@@ -290,7 +303,7 @@ function session(options){
 
     // generate the session
     function generate() {
-      if (generateSession) {
+      if (generateSession(req, res)) {
         store.generate(req);
       }
     }

--- a/test/session.js
+++ b/test/session.js
@@ -108,10 +108,23 @@ describe('connect.session()', function(){
     })
   })
   describe('generate option', function() {
-    it('should not generate a session when set to false', function(done){
+    it('should generate a session when function returns true', function(done){
       var app = connect()
         .use(connect.cookieParser())
-        .use(connect.session({ secret: 'keyboard cat', generate: false }))
+        .use(connect.session({ secret: 'keyboard cat', generate: function() { return true } }))
+        .use(respond);
+
+      app.request()
+      .get('/')
+      .end(function(res){
+        res.headers['set-cookie'].should.have.length(1);
+        done();
+      });
+    });
+    it('should not generate a session when function returns false', function(done){
+      var app = connect()
+        .use(connect.cookieParser())
+        .use(connect.session({ secret: 'keyboard cat', generate: function() { return false } }))
         .use(respond);
 
       app.request()
@@ -120,7 +133,7 @@ describe('connect.session()', function(){
         res.headers.should.not.have.property('set-cookie');
         done();
       });
-    })
+    });
   })
 
   it('should retain the sid', function(done){


### PR DESCRIPTION
Motivation behind this change is to offer finer-grained control over when new sessions are being created. An example use case would be to have an entire site use the session middleware to access session data if a user has already logged in. Without this option the middleware will automatically generate a new session for each user, when a more economical approach would be to only create the session once the user has need for one (e.g. login).

This pull request would solve #451, #822, #695
