### PR TITLE
Only set vary header if the filter check is passed

### DIFF
--- a/lib/middleware/compress.js
+++ b/lib/middleware/compress.js
@@ -82,19 +82,11 @@ module.exports = function compress(options) {
 
   return function compress(req, res, next){
     var accept = req.headers['accept-encoding']
-      , vary = res.getHeader('Vary')
       , write = res.write
       , end = res.end
       , compress = true
       , stream
       , method;
-
-    // vary
-    if (!vary) {
-      res.setHeader('Vary', 'Accept-Encoding');
-    } else if (!~vary.indexOf('Accept-Encoding')) {
-      res.setHeader('Vary', vary + ', Accept-Encoding');
-    }
 
     // see #724
     req.on('close', function(){
@@ -124,15 +116,23 @@ module.exports = function compress(options) {
     };
 
     res.on('header', function(){
+      // default request filter
+      if (!filter(req, res)) return;
+
+      // vary
+      var vary = res.getHeader('Vary');
+      if (!vary) {
+        res.setHeader('Vary', 'Accept-Encoding');
+      } else if (!~vary.indexOf('Accept-Encoding')) {
+        res.setHeader('Vary', vary + ', Accept-Encoding');
+      }
+
       if (!compress) return;
 
       var encoding = res.getHeader('Content-Encoding') || 'identity';
 
       // already encoded
       if ('identity' != encoding) return;
-
-      // default request filter
-      if (!filter(req, res)) return;
 
       // SHOULD use identity
       if (!accept) return;
@@ -164,7 +164,6 @@ module.exports = function compress(options) {
       res.removeHeader('Content-Length');
 
       // compression
-
       stream.on('data', function(chunk){
         write.call(res, chunk);
       });

--- a/test/compress.js
+++ b/test/compress.js
@@ -27,6 +27,12 @@ app.use('/streamsmall', function(req, res){
   res.end();
 });
 
+app.use('/image', function(req, res){
+  res.setHeader('Content-Type', 'image/png');
+  res.write(new Buffer(2048));
+  res.end();
+})
+
 describe('connect.compress()', function(){
   it('should gzip files', function(done){
     app.request()
@@ -73,10 +79,19 @@ describe('connect.compress()', function(){
     .expect('Vary', 'Accept-Encoding', done);
   })
 
-  it('should set Vary at all times', function(done){
+  it('should set Vary even if Accept-Encoding is not set', function(done){
     app.request()
     .get('/todo.txt')
     .expect('Vary', 'Accept-Encoding', done);
+  })
+
+  it('should not set Vary if Content-Type does not pass filter', function(done){
+    app.request()
+    .get('/image')
+    .end(function(res){
+      res.headers.should.not.have.property('vary');
+      done();
+    })
   })
 
   it('should transfer chunked', function(done){


### PR DESCRIPTION
pulled, fixed, and rebased from #849 - credits to @brightestcircle 
closes #848

note: i'd rather be liberal with the use of `vary`, but i don't think this will break anything since most CDNs only support `Accept-Encoding` in `Vary` headers anyways. if anyone complains, i will revert immediately.

actually, there's a test called `should set Vary at all times`, which this would obviously break. i also need to add a test.

i'll wait for @visionmedia to merge this.
