### PR TITLE
support mounting in connect.createServer

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -68,7 +68,11 @@ function createServer() {
   app.route = '/';
   app.stack = [];
   for (var i = 0; i < arguments.length; ++i) {
-    app.use(arguments[i]);
+    if (toString.apply(arguments[i]) == '[object Array]') {
+      app.use(arguments[i][0], arguments[i][1]);
+    } else {
+      app.use(arguments[i]);
+    }
   }
   return app;
 };

--- a/test/server.js
+++ b/test/server.js
@@ -89,4 +89,23 @@ describe('app', function(){
     .get('/foo/<script>stuff</script>')
     .expect('Cannot GET /foo/&lt;script&gt;stuff&lt;/script&gt;', done);
   })
+
+  it('should support mounting by passing an array containing a mount point and a middleware', function(done){
+    var app = connect.createServer(
+        connect.json()
+      , ['/test', function(req, res, next){ req.body.foo = 'baz'; next(); }]
+      , function(req, res){ res.end(JSON.stringify(req.body)); });
+
+    app.request()
+      .post('/')
+      .set('Content-Type', 'application/json')
+      .write('{"foo":"bar"}')
+      .expect('{"foo":"bar"}', function(){
+        app.request()
+          .post('/test')
+          .set('Content-Type', 'application/json')
+          .write('{"foo":"bar"}')
+          .expect('{"foo":"baz"}', done);
+      });
+  })
 })


### PR DESCRIPTION
To specify a mounted middleware in connect.createServer, you can pass an
array containing the mount point as a string in index 0 and the
middleware in index 1.
