### PR TITLE
Add typeof test to req.body method override

### DIFF
--- a/lib/middleware/methodOverride.js
+++ b/lib/middleware/methodOverride.js
@@ -32,7 +32,7 @@ module.exports = function methodOverride(key){
     req.originalMethod = req.originalMethod || req.method;
 
     // req.body
-    if (req.body && key in req.body) {
+    if (req.body && typeof req.body === 'object' && key in req.body) {
       method = req.body[key].toLowerCase();
       delete req.body[key];
     }


### PR DESCRIPTION
If `req.body` exists but is not an object, this causes an error.

```
TypeError: Cannot use 'in' operator to search for '_method' in value
    at Object.methodOverride [as handle] (/home/james/Projects/UmbraEngineering/dagger/node_modules/express/node_modules/connect/lib/middleware/methodOverride.js:29:31)
    at next (/home/james/Projects/UmbraEngineering/dagger/node_modules/express/node_modules/connect/lib/proto.js:190:15)
    at multipart (/home/james/Projects/UmbraEngineering/dagger/node_modules/express/node_modules/connect/lib/middleware/multipart.js:60:27)
    at /home/james/Projects/UmbraEngineering/dagger/node_modules/express/node_modules/connect/lib/middleware/bodyParser.js:57:9
    at urlencoded (/home/james/Projects/UmbraEngineering/dagger/node_modules/express/node_modules/connect/lib/middleware/urlencoded.js:48:27)
    at /home/james/Projects/UmbraEngineering/dagger/node_modules/express/node_modules/connect/lib/middleware/bodyParser.js:55:7
    at IncomingMessage.<anonymous> (/home/james/Projects/UmbraEngineering/dagger/node_modules/express/node_modules/connect/lib/middleware/json.js:82:9)
    at IncomingMessage.EventEmitter.emit (events.js:92:17)
    at _stream_readable.js:920:16
    at process._tickCallback (node.js:415:13)
```

I occasionally need to send non-object values that are still valid JSON, such as sending just a string. This simple `typeof` fixes that.
