### PR TITLE
When response time is zero, the logger writes a '-' instead of '0'

### DIFF
--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -267,7 +267,7 @@ exports.token('method', function(req){
  */
 
 exports.token('response-time', function(req){
-  return new Date - req._startTime;
+  return String(Date.now() - req._startTime);
 });
 
 /**


### PR DESCRIPTION
This changes the value returned by the response-time logger token to be a string instead of a number so that when the response time is zero, it will not be replaced with a dash (-) in the logs since the string of '0' is not falsy like a plain 0.
