### PR TITLE
Keep query string intact during directory redirect

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -63,10 +63,13 @@ exports = module.exports = function(root, options){
 
     function directory() {
       if (!redirect) return resume();
-      var pathname = url.parse(req.originalUrl).pathname;
+      var originalUrl = url.parse(req.originalUrl);
+      var target;
+      originalUrl.pathname += '/';
+      target = url.format(originalUrl);
       res.statusCode = 303;
-      res.setHeader('Location', pathname + '/');
-      res.end('Redirecting to ' + utils.escape(pathname) + '/');
+      res.setHeader('Location', target);
+      res.end('Redirecting to ' + utils.escape(target));
     }
 
     function error(err) {

--- a/test/static.js
+++ b/test/static.js
@@ -42,6 +42,12 @@ describe('connect.static()', function(){
     .expect('baz', done);
   })
 
+  it('should redirect directories with query string', function (done) {
+    app.request()
+    .get('/users?name=john')
+    .expect('Location', '/users/?name=john', done);
+  })
+
   it('should redirect directories', function(done){
     app.request()
     .get('/users')


### PR DESCRIPTION
This is a different fix to use the escaping mechanisms of `url.format` for the search string, and includes a test!

Fixes #792
Fixes #793
