### PR TITLE
Specify utf8 encoding in utils.md5

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,7 +81,7 @@ exports.error = function(code, msg){
 exports.md5 = function(str, encoding){
   return crypto
     .createHash('md5')
-    .update(str)
+    .update(str, 'utf8')
     .digest(encoding || 'hex');
 };
 


### PR DESCRIPTION
This specifies that the input string to `utils.md5` is utf8.

Fixes #288

This doesn't include any tests as this is not public functionality and doesn't actually change anything with how it is used internally, so it is dubious. As the only use case passes in a `Buffer` object, the encoding is just ignored.
