### PR TITLE
Prefer specific type over */* in directoy middleware

### DIFF
--- a/lib/middleware/directory.js
+++ b/lib/middleware/directory.js
@@ -89,7 +89,14 @@ exports = module.exports = function directory(root, options){
 
         // content-negotiation
         for (var key in exports) {
-          if (~accept.indexOf(key) || ~accept.indexOf('*/*')) {
+          if (~accept.indexOf(key)) {
+            exports[key](req, res, files, next, originalDir, showUp, icons);
+            return;
+          }
+        }
+
+        if (~accept.indexOf('*/*')) {
+          for (var key in exports) {
             exports[key](req, res, files, next, originalDir, showUp, icons);
             return;
           }

--- a/test/directory.js
+++ b/test/directory.js
@@ -1,5 +1,6 @@
 
 var connect = require('..');
+var utils = connect.utils;
 
 var app = connect();
 app.use(connect.directory('test/fixtures'));
@@ -12,6 +13,7 @@ describe('directory()', function(){
         .get('/')
         .set('Accept', 'application/json')
         .end(function(res){
+          utils.mime(res).should.equal('application/json');
           var arr = JSON.parse(res.body);
           arr.should.include('users');
           arr.should.include('file #1.txt');
@@ -22,12 +24,13 @@ describe('directory()', function(){
       });
     });
 
-    describe('when Accept: text/html is given', function () {
+    describe('of text/html', function () {
       it('should respond with html', function (done) {
         app.request()
         .get('/')
         .set('Accept', 'text/html')
         .end(function (res) {
+          utils.mime(res).should.equal('text/html');
           res.body.should.include('<a href="/users"');
           res.body.should.include('<a href="/file%20%231.txt"');
           res.body.should.include('<a href="/todo.txt"');
@@ -36,15 +39,33 @@ describe('directory()', function(){
       });
     });
 
-    describe('when Accept: text/plain is given', function () {
+    describe('of text/plain', function () {
       it('should respond with text', function (done) {
         app.request()
         .get('/')
         .set('Accept', 'text/plain')
         .end(function (res) {
+          utils.mime(res).should.equal('text/plain');
           res.body.should.include('users');
           res.body.should.include('file #1.txt');
           res.body.should.include('todo.txt');
+          done();
+        });
+      });
+    });
+
+    describe('of application/json, */*; q=0.01', function () {
+      it('should negotiate to json', function (done) {
+        app.request()
+        .get('/')
+        .set('Accept', 'application/json, */*; q=0.01')
+        .end(function(res){
+          utils.mime(res).should.equal('application/json');
+          var arr = JSON.parse(res.body);
+          arr.should.include('users');
+          arr.should.include('file #1.txt');
+          arr.should.include('nums');
+          arr.should.include('todo.txt');
           done();
         });
       });


### PR DESCRIPTION
This simply changes the content negotiation in the directory middleware to consider `*/*` last so a more specific type is picked.

Fixes #829
