### PR TITLE
Rewrite FQDN URLs correctly for mounted apps

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -100,10 +100,13 @@ app.use = function(route, fn){
 
 app.handle = function(req, res, out) {
   var stack = this.stack
-    , fqdn = ~req.url.indexOf('://')
+    , fqdn = 1 + req.url.indexOf('://')
+    , protohost = fqdn ? req.url.substr(0, req.url.indexOf('/', 2 + fqdn)) : ''
     , removed = ''
     , slashAdded = false
     , index = 0;
+
+  req.url = req.url.substr(protohost.length);
 
   function next(err) {
     var layer, path, status, c;
@@ -113,7 +116,7 @@ app.handle = function(req, res, out) {
       slashAdded = false;
     }
 
-    req.url = removed + req.url;
+    req.url = protohost + removed + req.url;
     req.originalUrl = req.originalUrl || req.url;
     removed = '';
 
@@ -170,7 +173,7 @@ app.handle = function(req, res, out) {
       // Call the layer handler
       // Trim off the part of the url that matches the route
       removed = layer.route;
-      req.url = req.url.substr(removed.length);
+      req.url = protohost + req.url.substr(protohost.length + removed.length);
 
       // Ensure leading slash
       if (!fqdn && '/' != req.url[0]) {

--- a/test/mounting.js
+++ b/test/mounting.js
@@ -49,6 +49,18 @@ describe('app.use()', function(){
       .expect('/post/1', done);
     })
 
+    it('should adjust FQDN req.url', function(done){
+      var app = connect();
+
+      app.use('/blog', function(req, res){
+        res.end(req.url);
+      });
+
+      app.request()
+      .get('http://example.com/blog/post/1')
+      .expect('http://example.com/post/1', done);
+    })
+
     it('should strip trailing slash', function(done){
       var blog = connect();
     


### PR DESCRIPTION
This adjusts the path re-writing for mounted apps to leave the protocol and host alone for FQDN URLs.

Fixes #769
