### PR TITLE
Fix directory middleware to properly work with '.'

### DIFF
--- a/lib/middleware/directory.js
+++ b/lib/middleware/directory.js
@@ -19,6 +19,7 @@ var fs = require('fs')
   , utils = require('../utils')
   , path = require('path')
   , normalize = path.normalize
+  , sep = path.sep
   , extname = path.extname
   , join = path.join;
 
@@ -53,7 +54,7 @@ exports = module.exports = function directory(root, options){
   var hidden = options.hidden
     , icons = options.icons
     , filter = options.filter
-    , root = normalize(root);
+    , root = normalize(root + sep);
 
   return function directory(req, res, next) {
     if ('GET' != req.method && 'HEAD' != req.method) return next();
@@ -64,7 +65,7 @@ exports = module.exports = function directory(root, options){
       , path = normalize(join(root, dir))
       , originalUrl = parse(req.originalUrl)
       , originalDir = decodeURIComponent(originalUrl.pathname)
-      , showUp = path != root && path != root + '/';
+      , showUp = path != root;
 
     // null byte(s), bad request
     if (~path.indexOf('\0')) return next(utils.error(400));

--- a/test/directory.js
+++ b/test/directory.js
@@ -4,6 +4,7 @@ var connect = require('..');
 var app = connect();
 app.use(connect.directory('test/fixtures'));
 
+
 describe('directory()', function(){
   describe('when given Accept: header', function () {
     describe('of application/json', function () {
@@ -81,4 +82,48 @@ describe('directory()', function(){
       .expect(403, done);
     });
   });
-})
+
+  describe('when set with trailing slash', function () {
+    var app = connect(connect.directory('test/fixtures/'));
+
+    it('should respond with file list', function (done) {
+      app.request()
+      .get('/')
+      .set('Accept', 'application/json')
+      .end(function(res){
+        res.statusCode.should.equal(200);
+        var arr = JSON.parse(res.body);
+        arr.should.include('users');
+        arr.should.include('file #1.txt');
+        arr.should.include('nums');
+        arr.should.include('todo.txt');
+        done();
+      });
+    });
+  });
+
+  describe('when set to \'.\'', function () {
+    var app = connect(connect.directory('.'));
+
+    it('should respond with file list', function (done) {
+      app.request()
+      .get('/')
+      .set('Accept', 'application/json')
+      .end(function(res){
+        res.statusCode.should.equal(200);
+        var arr = JSON.parse(res.body);
+        arr.should.include('LICENSE');
+        arr.should.include('lib');
+        arr.should.include('test');
+        done();
+      });
+    });
+
+    it('should not allow serving outside root', function (done) {
+      app.request()
+      .get('/../')
+      .set('Accept', 'text/html')
+      .expect(403, done);
+    });
+  });
+});


### PR DESCRIPTION
This fixes the `directory` middleware to properly work when the directory is set to `'.'`. Before it incorrectly allowed users to climb the entire directory tree outside the directory. This also does _not_ use `path.resolve` to work where a server cannot stat it's own parent directory (sort of common practice).

Fixes #771
