### PR TITLE
Store remote address at start of request for logger

### DIFF
--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -133,7 +133,9 @@ exports = module.exports = function logger(options) {
   }
 
   return function logger(req, res, next) {
+    var sock = req.socket;
     req._startTime = new Date;
+    req._remoteAddress = sock.socket ? sock.socket.remoteAddress : sock.remoteAddress;
 
     function logRequest(){
       res.removeListener('finish', logRequest);
@@ -300,6 +302,7 @@ exports.token('referrer', function(req){
 
 exports.token('remote-addr', function(req){
   if (req.ip) return req.ip;
+  if (req._remoteAddress) return req._remoteAddress;
   var sock = req.socket;
   if (sock.socket) return sock.socket.remoteAddress;
   return sock.remoteAddress;

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,0 +1,27 @@
+
+var connect = require('../');
+
+var lastLogLine;
+function saveLastLogLine(line) { lastLogLine = line; }
+
+var app = connect();
+
+app.use(connect.logger({'format': 'default', 'stream': {'write': saveLastLogLine}}));
+
+app.use(function (req, res) {
+  res.end(req.connection.remoteAddress);
+});
+
+describe('connect.logger()', function () {
+  describe('when Connection: close', function () {
+    it('should log the client ip', function (done) {
+      app.request()
+      .get('/')
+      .set('Connection', 'close')
+      .end(function (res) {
+        lastLogLine.should.startWith(res.body);
+        done();
+      });
+    })
+  })
+});


### PR DESCRIPTION
This makes logger store the remote address on the request at the beginning of the request so when the requests ends, it still has the IP address to log even if the socket is already closed.

Fix #811
