### PR TITLE
Fix static directory redirect for root mount point

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -55,6 +55,7 @@ exports = module.exports = function(root, options){
     if ('GET' != req.method && 'HEAD' != req.method) return next();
     var path = parse(req).pathname;
     var pause = utils.pause(req);
+    if (path == '/' && req.originalUrl.lastIndexOf('/') != req.originalUrl.length) return directory();
 
     function resume() {
       next();

--- a/test/static.js
+++ b/test/static.js
@@ -298,6 +298,20 @@ describe('connect.static()', function(){
   })
 
   describe('when mounted', function(){
+    it('should redirect when index at mount point', function (done) {
+      var app = connect();
+
+      app.use('/users', connect.static('test/fixtures/users'));
+
+      app.request()
+      .get('/users')
+      .end(function (res) {
+        res.should.have.status(303);
+        res.headers.location.should.equal('/users/');
+        done();
+      });
+    });
+
     it('should redirect relative to the originalUrl', function(done){
       var app = connect();
 


### PR DESCRIPTION
This fixes an issues where when the `static` middleware is mounted and the `redirect` option is set (which is the default), accessing the root mount point without a trailing stash doesn't correctly respond with a redirect.

Fixes #445
