### PR TITLE
Fix parsing URL that looks like protocol-relative auth

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -370,7 +370,14 @@ exports.parseUrl = function(req){
   if (parsed && parsed.href == req.url) {
     return parsed;
   } else {
-    return req._parsedUrl = parse(req.url);
+    parsed = parse(req.url);
+
+    if (parsed.auth && !parsed.protocol && ~parsed.href.indexOf('//')) {
+      // This parses pathnames, and a strange pathname like //r@e should work
+      parsed = parse(req.url.replace(/@/g, '%40'));
+    }
+
+    return req._parsedUrl = parsed;
   }
 };
 

--- a/test/static.js
+++ b/test/static.js
@@ -42,6 +42,12 @@ describe('connect.static()', function(){
     .expect('baz', done);
   })
 
+  it('should not choke on auth-looking URL', function(done){
+    app.request()
+    .get('//todo@txt')
+    .expect(404, done);
+  })
+
   it('should redirect directories with query string', function (done) {
     app.request()
     .get('/users?name=john')


### PR DESCRIPTION
I had some errors pop up in one of my servers yesterday from `static` due to a weird URL that was requested. A request like `GET //rock@me HTTP/1.1` where the `static` middleware is mounted at the root causes an error, as the pathname of the URL is passed through to `url.parse` which treats URLs that start with `//` and have `blah@blah` next as an absolute URL with auth on purpose. I added a nice work-around where that will detect this and swap the `@` to `%40` (as it should have been, but sadly we cannot control the clients) and re-parse the URL. The changed routine memorizes the parses, which works out fine for performance.

`url.parse` was really meant to parse full URLs, and using it to just parse pathnames is already a hack (even noted in some commits in node itself), which is why this case happens to fail :-/
