### PR TITLE
Fix mounted path splitting to ignore search part

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -100,7 +100,9 @@ app.use = function(route, fn){
 
 app.handle = function(req, res, out) {
   var stack = this.stack
-    , fqdn = 1 + req.url.indexOf('://')
+    , search = 1 + req.url.indexOf('?')
+    , pathlength = search ? search - 1 : req.url.length
+    , fqdn = 1 + req.url.substr(0, pathlength).indexOf('://')
     , protohost = fqdn ? req.url.substr(0, req.url.indexOf('/', 2 + fqdn)) : ''
     , removed = ''
     , slashAdded = false

--- a/test/mounting.js
+++ b/test/mounting.js
@@ -49,6 +49,18 @@ describe('app.use()', function(){
       .expect('/post/1', done);
     })
 
+    it('should ignore FQDN in search', function (done) {
+      var app = connect();
+
+      app.use('/proxy', function (req, res) {
+        res.end(req.url);
+      });
+
+      app.request()
+      .get('/proxy?url=http://example.com/blog/post/1')
+      .expect('/?url=http://example.com/blog/post/1', done);
+    });
+
     it('should adjust FQDN req.url', function(done){
       var app = connect();
 


### PR DESCRIPTION
This fixes the mounting to ignore what looks like FQDNs in the search part of the URL, which fixes URL mangling then passing plain FQDNs in the search part.

Fixes #939
