### PR TITLE
Fix a bug in the new static root redirect w.r.t. trailing slashes

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -53,9 +53,13 @@ exports = module.exports = function(root, options){
 
   return function staticMiddleware(req, res, next) {
     if ('GET' != req.method && 'HEAD' != req.method) return next();
+    var originalUrl = url.parse(req.originalUrl);
     var path = parse(req).pathname;
     var pause = utils.pause(req);
-    if (path == '/' && req.originalUrl.lastIndexOf('/') != req.originalUrl.length) return directory();
+
+    if (path == '/' && originalUrl.pathname[originalUrl.pathname.length - 1] != '/') {
+      return directory();
+    }
 
     function resume() {
       next();
@@ -64,7 +68,6 @@ exports = module.exports = function(root, options){
 
     function directory() {
       if (!redirect) return resume();
-      var originalUrl = url.parse(req.originalUrl);
       var target;
       originalUrl.pathname += '/';
       target = url.format(originalUrl);

--- a/test/static.js
+++ b/test/static.js
@@ -60,6 +60,12 @@ describe('connect.static()', function(){
     .expect(303, done);
   })
 
+  it('should not redirect incorrectly', function (done) {
+    app.request()
+    .get('/')
+    .expect(404, done);
+  });
+
   it('should support index.html', function(done){
     app.request()
     .get('/users/')


### PR DESCRIPTION
This fixes a bug where the static middleware did not properly detect that the pathname ended in a slash before sending a redirect for the root mount point.

Fixes visionmedia/express#1789
