### PR TITLE
Return early from removeContentHeaders if res._headers is null

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -273,6 +273,7 @@ exports.pause = exports.brokenPause
  */
 
 exports.removeContentHeaders = function(res){
+  if (!res._headers) return;
   Object.keys(res._headers).forEach(function(field){
     if (0 == field.indexOf('content')) {
       res.removeHeader(field);


### PR DESCRIPTION
Not sure if it's useful since this is a private API method. But I happened to invoke with headers set to `null` from another project.
