### PR TITLE
Optional Rolling Sessions

### DIFF
--- a/examples/rollingSession.js
+++ b/examples/rollingSession.js
@@ -1,0 +1,64 @@
+
+var connect = require('../')
+var http = require('http');
+
+var hour = 60 * 60 * 1000;
+
+// maxAge session without the rolling option
+// it doesn't update the maxAge value
+
+http.createServer(connect()
+  .use(connect.cookieParser())
+  .use(connect.session({ secret  : 'keyboard cat',
+                         key     : 'NoRolling.sid',
+                         cookie  : { maxAge: hour }}))
+  .use(connect.favicon())
+  .use(clear)
+  .use(change)
+  .use(counter)
+  ).listen(3000);
+console.log('port 3000: without rolling, session CANNOT be changed to browser session');
+
+// maxAge session with the rolling option
+// it always updates the maxAge value
+
+http.createServer(connect()
+  .use(connect.cookieParser())
+  .use(connect.session({ secret  : 'keyboard cat',
+                         key     : 'Rolling.sid',
+                         cookie  : { maxAge: hour },
+                         rolling : true}))
+  .use(connect.favicon())
+  .use(clear)
+  .use(change)
+  .use(counter)
+  ).listen(3001);
+console.log('port 3001: with rolling, session CAN be changed to browser session');
+
+function clear(req, res, next) {
+  if ('/clear' != req.url) return next();
+  req.session.regenerate(function(err){});
+  res.statusCode = 302;
+  res.setHeader('Location', '/');
+  res.end();
+}
+function change(req, res, next) {
+  if ('/change' != req.url) return next();
+  req.session.cookie.maxAge = req.session.cookie.maxAge ? null : hour;
+  res.statusCode = 302;
+  res.setHeader('Location', '/');
+  res.end();
+}
+function counter(req, res) {
+  req.session.count = req.session.count || 0;
+  var n = req.session.count++;
+  var expiration = req.session.cookie.maxAge
+    ? req.session.cookie.maxAge + "msec"
+    : "browser session";
+  res.end('<p>Expiration: ' + expiration + '</p>'
+    + '<p>Hits: ' + n + '</p>'
+    + '<p><a href="/clear">clear session</a></p>'
+    + (req.session.cookie.maxAge
+        ? '<p><a href="/change">Change to Browser Session</a></p>'
+        : '<p><a href="/change">Change to maxAge Session</a></p>'));
+}

--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -190,7 +190,8 @@ function session(options){
     , store = options.store || new MemoryStore
     , cookie = options.cookie || {}
     , trustProxy = options.proxy
-    , storeReady = true;
+    , storeReady = true
+    , rollingSessions = options.rolling || false;
 
   // notify user that this store is not
   // meant for a production environment
@@ -254,15 +255,20 @@ function session(options){
       // only send secure cookies via https
       if (cookie.secure && !tls) return debug('not secured');
 
-      // long expires, handle expiry server-side
-      if (!isNew && cookie.hasLongExpires) return debug('already set cookie');
-
-      // browser-session length cookie
-      if (null == cookie.expires) {
-        if (!isNew) return debug('already set browser-session cookie');
-      // compare hashes and ids
-      } else if (originalHash == hash(req.session) && originalId == req.session.id) {
-        return debug('unmodified session');
+      // in case of rolling session, always reset the cookie
+      if (!rollingSessions) {
+      
+        // long expires, handle expiry server-side
+        if (!isNew && cookie.hasLongExpires) return debug('already set cookie');
+  
+        // browser-session length cookie
+        if (null == cookie.expires) {
+          if (!isNew) return debug('already set browser-session cookie');
+        // compare hashes and ids
+        } else if (originalHash == hash(req.session) && originalId == req.session.id) {
+          return debug('unmodified session');
+        }
+        
       }
 
       var val = 's:' + signature.sign(req.sessionID, secret);

--- a/test/rollingSession.js
+++ b/test/rollingSession.js
@@ -1,0 +1,70 @@
+
+var connect = require('../');
+
+var min = 60 * 1000;
+
+function normal(req, res, next) {
+  if ('/' != req.url) return next();
+  res.end();
+}
+function changeToNull(req, res, next) {
+  if ('/changeToNull' != req.url) return next();
+  req.session.cookie.maxAge = null;
+  res.end();
+}
+
+describe('Rolling Session', function(){
+
+  describe('Session without Rolling.', function(){
+    it('Should send the cookie just the first get. So cannot get the change to browser session', function (done) {
+      var app = connect()
+        .use(connect.cookieParser())
+        .use(connect.session({ secret: 'keyboard cat',
+                               cookie: { maxAge: min }}))
+        .use(normal) 
+        .use(changeToNull);
+
+      app.request()
+        .get('/')
+        .end(function(res){
+          res.headers.should.have.property('set-cookie');
+          res.headers['set-cookie'][0].should.include('Expires');
+          app.request()
+            .get('/changeToNull')
+            .set('Cookie', res.headers['set-cookie'][0])
+            .end(function(res){
+              res.headers.should.not.have.property('set-cookie');
+              done();
+            });
+          });
+    });
+  });
+
+  describe('Session with Rolling.', function(){
+    it('Every get send the cookie, so can get the change to browser session', function (done) {
+      var app = connect()
+        .use(connect.cookieParser())
+        .use(connect.session({ secret  : 'keyboard cat',
+                               cookie  : { maxAge: min },
+                               rolling : true}))
+        .use(normal) 
+        .use(changeToNull);
+
+      app.request()
+        .get('/')
+        .end(function(res){
+          res.headers.should.have.property('set-cookie');
+          res.headers['set-cookie'][0].should.include('Expires');
+          app.request()
+            .get('/changeToNull')
+            .set('Cookie', res.headers['set-cookie'][0])
+            .end(function(res){
+              res.headers.should.have.property('set-cookie');
+              res.headers['set-cookie'][0].should.not.include('Expires');
+              done();
+            });
+          });
+    });
+  });
+
+});


### PR DESCRIPTION
Included the "rolling" option. In this way if we need any change of the cookie it will be automatically made available.
A typical example of usage is for the "Remind Me" sessions, where maxAge may vary from null to the prefixed amount of time, depending on the user selection.

Usage:
connect()
  .use(connect.cookieParser())
  .use(connect.session({ secret: 'keyboard cat', key: 'sid', cookie: { secure: true }, rolling : true}))
