### PR TITLE
Fix FQDN mounting with multiple handlers

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -108,8 +108,6 @@ app.handle = function(req, res, out) {
     , slashAdded = false
     , index = 0;
 
-  req.url = req.url.substr(protohost.length);
-
   function next(err) {
     var layer, path, c;
 
@@ -118,7 +116,7 @@ app.handle = function(req, res, out) {
       slashAdded = false;
     }
 
-    req.url = protohost + removed + req.url;
+    req.url = removed + req.url;
     req.originalUrl = req.originalUrl || req.url;
     removed = '';
 

--- a/test/mounting.js
+++ b/test/mounting.js
@@ -73,6 +73,22 @@ describe('app.use()', function(){
       .expect('http://example.com/post/1', done);
     })
 
+    it('should adjust FQDN req.url with multiple handlers', function(done){
+      var app = connect();
+
+      app.use(function(req,res,next) {
+        next();
+      });
+
+      app.use('/blog', function(req, res){
+        res.end(req.url);
+      });
+
+      app.request()
+      .get('http://example.com/blog/post/1')
+      .expect('http://example.com/post/1', done);
+    })
+
     it('should strip trailing slash', function(done){
       var blog = connect();
     


### PR DESCRIPTION
Fixes issue with FQDN rewrite when there are multiple handlers (such as logging or coming from express).  The protohost is getting duplicated with each handler in the stack.  For example with two handlers req.url would end up being "http://example.comhttp://example.comhttp://example.com/blog/post/1".
