### PR TITLE
Fix FQDN url with multiple routed handlers

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -116,7 +116,7 @@ app.handle = function(req, res, out) {
       slashAdded = false;
     }
 
-    req.url = removed + req.url;
+    req.url = protohost + removed + req.url.substr(protohost.length);
     req.originalUrl = req.originalUrl || req.url;
     removed = '';
 

--- a/test/mounting.js
+++ b/test/mounting.js
@@ -89,6 +89,21 @@ describe('app.use()', function(){
       .expect('http://example.com/post/1', done);
     })
 
+    it('should adjust FQDN req.url with multiple routed handlers', function(done) {
+      var app = connect();
+    
+      app.use('/blog', function(req,res,next) {       
+        next();
+      });
+      app.use('/blog', function(req, res) {
+        res.end(req.url);
+      });
+
+      app.request()
+      .get('http://example.com/blog/post/1')
+      .expect('http://example.com/post/1', done);
+    })
+
     it('should strip trailing slash', function(done){
       var blog = connect();
     


### PR DESCRIPTION
Fixes FQDN urls when there are multiple handlers with routes.  Previously, it would apply the removed path to the full path, ie: bloghttp://example.com/post/1.  

This functionality adds another use case to testing surrounding https://github.com/senchalabs/connect/pull/945
