### PR TITLE
Fix cookieSession to work with FQDN

### DIFF
--- a/lib/middleware/cookieSession.js
+++ b/lib/middleware/cookieSession.js
@@ -59,7 +59,7 @@ module.exports = function cookieSession(options){
     var cookie = req.session.cookie = new Cookie(options.cookie);
 
     // pathname mismatch
-    if (0 != req.originalUrl.indexOf(cookie.path)) return next();
+    if (0 != req.originalPath.indexOf(cookie.path)) return next();
 
     // cookieParser secret
     if (!options.secret && req.secret) {

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -118,6 +118,7 @@ app.handle = function(req, res, out) {
 
     req.url = protohost + removed + req.url.substr(protohost.length);
     req.originalUrl = req.originalUrl || req.url;
+    req.originalPath = req.originalPath || (removed + req.url.substr(protohost.length));
     removed = '';
 
     // next callback

--- a/test/mounting.js
+++ b/test/mounting.js
@@ -37,6 +37,42 @@ describe('app.use()', function(){
       .expect('/blog/post/1', done);
     })
 
+    it('should retain req.originalPath', function(done){
+      var app = connect();
+
+      app.use('/blog', function(req, res){
+        res.end(req.originalPath);
+      });
+
+      app.request()
+      .get('/blog/post/1')
+      .expect('/blog/post/1', done);
+    })
+
+    it('should retain FQDN req.originaPath', function(done){
+      var app = connect();
+
+      app.use('/blog', function(req, res){
+        res.end(req.originalPath);
+      });       
+
+      app.request()
+      .get('http://example.com/blog/post/1')
+      .expect('/blog/post/1', done);
+    })
+   
+    it('should retain FQDN req.originalUrl', function(done) {
+      var app = connect();
+
+      app.use('/blog', function(req, res){
+        res.end(req.originalUrl);
+      });
+
+      app.request()
+      .get('http://example.com/blog/post/1')
+      .expect('http://example.com/blog/post/1', done)
+    });
+
     it('should adjust req.url', function(done){
       var app = connect();
     


### PR DESCRIPTION
Changes the cookieSession to check the path instead of the url, which doesn't work with FQDN :( 

I created a new variable on req for storing the originalPath (along with the originalUrl) that can be used in middleware without having to strip out the protocol/host details from the originalUrl. This is not getting set in the same manner as originalUrl.
