### PR TITLE
errorHandler: use setHeader instead of writeHead

### DIFF
--- a/lib/middleware/errorHandler.js
+++ b/lib/middleware/errorHandler.js
@@ -73,7 +73,7 @@ exports = module.exports = function errorHandler(){
       res.end(json);
     // plain text
     } else {
-      res.writeHead(res.statusCode, { 'Content-Type': 'text/plain' });
+      res.setHeader('Content-Type', 'text/plain');
       res.end(err.stack);
     }
   };


### PR DESCRIPTION
The errorHandler still uses writeHead for the plain text response. This can cause the following exception by node: `Can't render headers after they are sent to the client.`
