### PR TITLE
Improve logging for error objects that don't have a stack property

### DIFF
--- a/lib/middleware/errorHandler.js
+++ b/lib/middleware/errorHandler.js
@@ -10,7 +10,8 @@
  */
 
 var utils = require('../utils')
-  , fs = require('fs');
+  , fs = require('fs')
+  , inspect = require('util').inspect;
 
 // environment
 
@@ -45,7 +46,7 @@ exports = module.exports = function errorHandler(){
   return function errorHandler(err, req, res, next){
     if (err.status) res.statusCode = err.status;
     if (res.statusCode < 400) res.statusCode = 500;
-    if ('test' != env) console.error(err.stack);
+    if ('test' != env) console.error(err.stack || inspect(err, false, null));
     var accept = req.headers.accept || '';
     // html
     if (~accept.indexOf('html')) {


### PR DESCRIPTION
Although using strings or plain objects as error types is generally a bad practice in node, the `errorHandler` middleware currently logs `undefined` when it encounters this scenario which isn't really helpful.
