### PR TITLE
generator support via co

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 	@NODE_ENV=test ./node_modules/.bin/mocha \
 		--reporter $(REPORTER) \
 		--timeout 600 \
-		--bail \
+		--harmony-generators \
 		$(TESTS)
 
 docs: $(HTML)

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -10,6 +10,7 @@
  */
 
 var http = require('http')
+  , co = require('co')
   , utils = require('./utils')
   , debug = require('debug')('connect:dispatcher');
 
@@ -183,20 +184,26 @@ app.handle = function(req, res, out) {
 
       debug('%s %s : %s', layer.handle.name || 'anonymous', layer.route, req.originalUrl);
       var arity = layer.handle.length;
+      var isGeneratorFunction = utils.isGeneratorFunction(layer.handle);
       if (err) {
         if (arity === 4) {
-          layer.handle(err, req, res, next);
+          if (isGeneratorFunction) co(layer.handle)(err, req, res, next, nextOnError);
+          else layer.handle(err, req, res, next);
         } else {
           next(err);
         }
       } else if (arity < 4) {
-        layer.handle(req, res, next);
+        if (isGeneratorFunction) co(layer.handle)(req, res, next, nextOnError);
+        else layer.handle(req, res, next);
       } else {
         next();
       }
     } catch (e) {
       next(e);
     }
+  }
+  function nextOnError(err) {
+    if (err) next(err);
   }
   next();
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -405,4 +405,16 @@ exports.normalizeSlashes = function normalizeSlashes(path) {
   return path.split(sep).join('/');
 };
 
+/**
+ * Check if `obj` is a generator function.
+ *
+ * @param {Mixed} obj
+ * @return {Boolean}
+ * @api private
+ */
+
+exports.isGeneratorFunction = function isGeneratorFunction(obj) {
+  return obj && obj.constructor && 'GeneratorFunction' == obj.constructor.name;
+}
+
 function noop() {}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "repository": "git://github.com/senchalabs/connect.git",
   "author": "TJ Holowaychuk <tj@vision-media.ca> (http://tjholowaychuk.com)",
   "dependencies": {
+    "co": "2.2.0",
     "qs": "0.6.5",
     "cookie-signature": "1.0.1",
     "buffer-crc32": "0.2.1",

--- a/test/generators.js
+++ b/test/generators.js
@@ -1,0 +1,131 @@
+var connect = require('../');
+
+function wait(done) {
+  setImmediate(done);
+}
+
+describe('connect.use(gen)', function(){
+  it('should work', function(done){
+    var app = connect();
+
+    app.use(function(req, res, next){
+      setImmediate(next);
+    })
+
+    app.use(function *(req, res){
+      yield wait;
+      res.statusCode = 204;
+      res.end();
+    })
+
+    app.request()
+    .get('/')
+    .expect(204, done);
+  })
+
+  it('should work with next()', function(done){
+    var app = connect();
+
+    app.use(function(req, res, next){
+      setImmediate(next);
+    })
+
+    app.use(function *(req, res, next){
+      yield wait;
+      next();
+    })
+
+    app.use(function(req, res, next){
+      setImmediate(next);
+    })
+
+    app.use(function *(req, res, next){
+      yield wait;
+      res.statusCode = 204;
+      res.end();
+    })
+
+    app.request()
+    .get('/')
+    .expect(204, done);
+  })
+
+  it('should not work with yield next', function(){
+    // Not sure how to test it.
+  })
+
+  it('should compose downstream', function(done){
+    var app = connect();
+
+    var arr = [];
+
+    app.use(function(req, res, next){
+      arr.push(1);
+      setImmediate(next);
+    })
+
+    app.use(function *(req, res, next){
+      yield wait;
+      arr.push(2);
+      next();
+    })
+
+    app.use(function(req, res, next){
+      arr.push(3);
+      setImmediate(next);
+    })
+
+    app.use(function *(req, res, next){
+      yield wait;
+      arr.push(4);
+      res.statusCode = 204;
+      res.end();
+    })
+
+    app.request()
+    .get('/')
+    .expect(204, done);
+  })
+
+  it('should not catch downstream errors', function(){
+    // Not sure how to test it.
+  })
+
+  it('should work as an error handler', function(done){
+    var app = connect();
+    var err = new Error();
+
+    app.use(function(req, res, next){
+      next(err);
+    })
+
+    app.use(function *(err2, req, res, next){
+      err.should.equal(err2);
+      res.statusCode = 204;
+      res.end();
+    })
+
+    app.request()
+    .get('/')
+    .expect(204, done);
+  })
+
+  it('should pass errors to the error handler', function(done){
+    var app = connect();
+    var err = new Error();
+
+    app.use(function *(){
+      throw err;
+    })
+
+    app.use(function *(err2, req, res, next){
+      err.should.equal(err2);
+      res.statusCode = 204;
+      res.end();
+    })
+
+    app.request()
+    .get('/')
+    .expect(204, done);
+  })
+})


### PR DESCRIPTION
to cure callback hell.

``` js
app.use(function *(req, res, next){
  req.user = yield User.get;
  next();
})
```

100% backwards compatible. unlike [koa](https://github.com/koajs/koa), `next` is not yieldable. you still do `next()`, not `yield next`. 

comments welcomed.

To do:
- [ ] Error if the user tries to `yield next`
