### PR TITLE
ending default 404 handler with a newline

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -155,7 +155,7 @@ app.handle = function(req, res, out) {
         res.statusCode = 404;
         res.setHeader('Content-Type', 'text/html');
         if ('HEAD' == req.method) return res.end();
-        res.end('Cannot ' + utils.escape(req.method) + ' ' + utils.escape(req.originalUrl));
+        res.end('Cannot ' + utils.escape(req.method) + ' ' + utils.escape(req.originalUrl) + '\n');
       }
       return;
     }

--- a/test/server.js
+++ b/test/server.js
@@ -87,6 +87,6 @@ describe('app', function(){
     var app = connect();
     app.request()
     .get('/foo/<script>stuff</script>')
-    .expect('Cannot GET /foo/&lt;script&gt;stuff&lt;/script&gt;', done);
+    .expect('Cannot GET /foo/&lt;script&gt;stuff&lt;/script&gt;\n', done);
   })
 })


### PR DESCRIPTION
I suggest to add a newline after a default 404 handler.

It doesn't matter if you're getting this using a browser, but if you request a page in console, weird thing would happen:

```
alex@server:~/bin$ curl http://localhost:4873/non/existent/page
Cannot GET /non/existent/pagealex@server:~/bin$ 
```

Not a big issue, I'm just tired of seeing this. :)
