### PR TITLE
Compress all XML data types.

### DIFF
--- a/lib/middleware/compress.js
+++ b/lib/middleware/compress.js
@@ -27,7 +27,7 @@ exports.methods = {
  */
 
 exports.filter = function(req, res){
-  return /json|text|javascript|dart|image\/svg\+xml|application\/x-font-ttf|application\/vnd\.ms-opentype|application\/vnd\.ms-fontobject/.test(res.getHeader('Content-Type'));
+  return /json|text|javascript|dart|xml|x-font-ttf|ms-opentype|ms-fontobject/.test(res.getHeader('Content-Type'));
 };
 
 /**


### PR DESCRIPTION
XML is just text with fancy notation, so it should all be compressible, just like HTML.. which, of course, is XML.

I have compiled a list of common internet media types and went through them searching for xml Internet Media Types to make sure they were primarily text.

These are the relevant parts of the messy list found at https://github.com/Fishrock123/Compressible-Types
- [x] application/atom+xml - http://en.wikipedia.org/wiki/Atom_(standard)
- [x] application/rdf+xml - http://en.wikipedia.org/wiki/RDF/XML
- [x] application/rss+xml
- [x] application/soap+xml - http://en.wikipedia.org/wiki/SOAP
- [x] application/xhtml+xml
- [x] application/xml
- [x] application/xml-dtd - Appears to be. - http://en.wikipedia.org/wiki/Document_type_definition
- [x] application/xop+xml - I think this should be ok. Use is far and few between. Format is similar to .ai files.
- [x] image/svg+xml
- [x] message/imdn+xml - IM datatype. Entirely text/xml as far as I can tell - http://tools.ietf.org/html/rfc5438
- [x] model/x3d+xml - xml. - http://edutechwiki.unige.ch/en/X3D_file_structure
- [x] text/xml
- [x] application/vnd.mozilla.xul+xml - just xml. - http://en.wikipedia.org/wiki/XUL
- [x] application/vnd.google-earth.kml+xml - also just xml. - https://developers.google.com/kml/documentation/kml_tut

The only one that contains any amount of non-text data is application/xop+xml, which to the best of my knowledge is seldomly used. And while compressing it may not always be optimal, in general use it should still see some small filesize gzippablity.

Simplifying the regex for font files may actually slightly decrease it's performance, I had a JSPerf somewhere but lost it a while ago. I think it will make up for the readability in the wiki and source.
