### PR TITLE
Add ability to chain middlewares in app.use()

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -58,11 +58,16 @@ var env = process.env.NODE_ENV || 'development';
  * @api public
  */
 
-app.use = function(route, fn){
+app.use = function(/*route, fn*/){
+  var route = arguments[0];
+  var fn = arguments[1];
+  var fns = Array.prototype.slice.call(arguments, 2);
+
   // default route to '/'
   if ('string' != typeof route) {
     fn = route;
     route = '/';
+    fns = Array.prototype.slice.call(arguments, 1);
   }
 
   // wrap sub-apps
@@ -87,6 +92,10 @@ app.use = function(route, fn){
   // add the middleware
   debug('use %s %s', route || '/', fn.name || 'anonymous');
   this.stack.push({ route: route, handle: fn });
+
+  fns.forEach(function (fn) {
+    app.use.call(this, route || '/', fn);
+  }.bind(this));
 
   return this;
 };

--- a/test/mounting.js
+++ b/test/mounting.js
@@ -199,4 +199,42 @@ describe('app.use()', function(){
     .get('/blOG')
     .expect('blog', done);
   })
+
+  it('should be possible to chain middlewares with mount point', function(done){
+    var app = connect();
+
+    app.use('/blog',
+      function(req, res, next){
+        res.firstMiddleware = true;
+        next();
+      },
+      function(req, res){
+        res.firstMiddleware.should.be.true;
+        res.end('blog');
+      }
+    );
+
+    app.request()
+    .get('/blog')
+    .expect('blog', done);
+  })
+
+  it('should be possible to chain middlewares without mount point', function(done){
+    var app = connect();
+
+    app.use(
+      function(req, res, next){
+        res.firstMiddleware = true;
+        next();
+      },
+      function(req, res){
+        res.firstMiddleware.should.be.true;
+        res.end('blog');
+      }
+    );
+
+    app.request()
+    .get('/')
+    .expect('blog', done);
+  })
 })


### PR DESCRIPTION
In my app, i have some code like this :

``` js
app.use('/blog', requireLogin());
app.use('/blog', blogApp);
```

It's not very nice.. it will be great if i could write :

``` js
app.use('/blog', requireLogin(), blogApp);
```

Just like in express routes.

It's why i write this pull request, tests are OK but may be i missed something.
