### PR TITLE
Adding destroy convenience method

### DIFF
--- a/lib/middleware/cookieSession.js
+++ b/lib/middleware/cookieSession.js
@@ -99,7 +99,7 @@ module.exports = function cookieSession(options){
      */
      
     req.session.destroy = function deleteCookieSession(sid, callback) {
-      delete req.session;
+      req.session = null;
       callback && callback();
     }
 


### PR DESCRIPTION
Adding this takes my code from this:

``` javascript
if (req.session.destroy) {
  req.session.destroy();
} else {
  delete req.session;
}
```

to

``` javascript
req.session.destroy();
```

Wins:
1. Readability
2. Making the learning curve less steep
3. Less lines

There is a use case when I may want to use a cookieSession in one environment, but a sessionStore in another. With a [sessionStore](http://www.senchalabs.org/connect/session.html), it must implement the `destroy` method. Not having the destroy method on the cookieSession makes it so I can trust that the session will always have a `destroy` method regardless of the type of session I'm using.

I can't think of a reason this shouldn't be accepted. Thanks!
