### PR TITLE
Modified path used by favicon.js to load default icon...

### DIFF
--- a/lib/middleware/favicon.js
+++ b/lib/middleware/favicon.js
@@ -48,7 +48,7 @@ var fs = require('fs')
 
 module.exports = function favicon(path, options){
   var options = options || {}
-    , path = path || __dirname + '/../public/favicon.ico'
+    , path = (fs.existsSync(path)) ? path : __dirname + '/../public/favicon.ico'
     , maxAge = options.maxAge || 86400000
     , icon; // favicon cache
 


### PR DESCRIPTION
Modified path used by favicon.js to load default icon not only if not specified by the app, but also if app specified path does not exist, thus preventing the app from throwing an error for favicon.ico file not found.
