### PR TITLE
Added a couple options to the CSRF API

### DIFF
--- a/lib/middleware/csrf.js
+++ b/lib/middleware/csrf.js
@@ -40,6 +40,8 @@ var crypto = require('crypto');
 module.exports = function csrf(options) {
   options = options || {};
   var value = options.value || defaultValue;
+  var methodIgnoreList = options.methodIgnoreList || ['GET', 'HEAD', 'OPTIONS'];
+  var entryPoint = options.entryPoint;
 
   return function(req, res, next){
     
@@ -73,7 +75,13 @@ module.exports = function csrf(options) {
       });
       
       // ignore these methods
-      if ('GET' == req.method || 'HEAD' == req.method || 'OPTIONS' == req.method) return next();
+      var method = req.method;
+      for (var i = 0; i < methodIgnoreList.length; i++) {
+        if (methodIgnoreList[i] === method) return next();
+      }
+      
+      // ignore entry point
+      if (entryPoint && entryPoint.path === req.path && entryPoint.method === method) return next();
       
       // determine user-submitted value
       var val = value(req);


### PR DESCRIPTION
Now an entry point can be defined (where a user-submitted value is not yet required) and the methods to ignore can be specified (while they still default to 'GET', 'HEAD', and 'OPTIONS'). E.g.:

```
var options = {
    value: function defaultValue(req) {
        return req.headers['x-csrf-token'];
    },
    methodIgnoreList: ['OPTIONS'],
    entryPoint: {
        path: '/sessions',
        method: 'POST'
    }
};
```
