### PR TITLE
directory: fix missing directory icon for ..

### DIFF
--- a/lib/middleware/directory.js
+++ b/lib/middleware/directory.js
@@ -339,7 +339,6 @@ function stat(dir, files, cb) {
  */
 
 var icons = {
-
     '.js': 'page_white_code_red.png'
   , '.json': 'page_white_code.png'
   , '.c': 'page_white_c.png'
@@ -462,5 +461,4 @@ var icons = {
 
   , 'folder': 'folder.png'
   , 'default': 'page_white.png'
-
 };


### PR DESCRIPTION
In directories that did not contain sub-directories, styling was not being applied to the `..` file. This fix makes `..` receive styling.

I had to consider whether earlier authors intended that `..` receive styling. The code's intent seemed conflicted.
- iconStyle() had a `continue` if the file's name was `..`, suggesting that there shouldn't be styling for it.
- iconStyle() _would_ have considered `..` a directory 2 lines later.
- html() considered `..` a directory.

Given that iconStyle() seemed to be explicitly trying to prevent `..` from receiving styling, and that in the latter two points, it seemed that `..` was only being considered a directory as a side effect of avoiding file.stat calls, I came to the initial assumption that it was intended for `..` to not receive styling.

However, I later considered the following:
- The `continue` statement may been an old optimization.
- Everything else _did_ seem to be hinting that `..` should be considered a "directory".
- If you click on `..`, you are taken to another directory. Not displaying an icon could be a way of indicating that `..` is not a _sub_-directory; but it is still a directory, so its icon should reflect its behavior.

Also:
- Some FTP clients (like Filezilla) display a folder icon for `..`.
- Online directories like <a href="http://cdimage.debian.org/debian-cd/7.3.0/amd64/">Debian's</a> use a twisting arrow to signify the parent directory. I checked the Silk icons but could not find an icon which I thought adequately represented the idea of "going back" or "going up one."

While a twisting arrow might do a better job of communicating the significance of `..` (along with labeling `..` as "Parent Directory" instead), I have decided to not make that change at this time, and instead simply use the folder icon for `..`. The folder icon has an intrinsic meaning _nearly_-consistent with `..`, and in my opinion it is preferable to none at all.

It's also worth consider that non-UNIX-savvy users will not know what `..` is and thus be confused. The folder icon may alleviate their confusion slightly, but ultimately it may be better to label it "Parent Directory" instead.
