### PR TITLE
logger: added conditional logging via 'skip' function in options.

### DIFF
--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -34,6 +34,7 @@ var defaultBufferDuration = 1000;
  *   - `stream`  Output stream, defaults to _stdout_
  *   - `buffer`  Buffer duration, defaults to 1000ms when _true_
  *   - `immediate`  Write log line on request instead of response (for response times)
+ *   - `skip`    If function, and `skip(req,res)` is truthy, request won't be logged.
  *
  * Tokens:
  *
@@ -67,6 +68,7 @@ var defaultBufferDuration = 1000;
  *      connect.logger(':method :url - :referrer')
  *      connect.logger(':req[content-type] -> :res[content-type]')
  *      connect.logger(function(tokens, req, res){ return 'some format string' })
+ *      connect.logger({ format: 'dev', skip(req,res){ return res.statusCode===304; }})
  *
  * Defining Tokens:
  *
@@ -140,6 +142,7 @@ exports = module.exports = function logger(options) {
     function logRequest(){
       res.removeListener('finish', logRequest);
       res.removeListener('close', logRequest);
+      if(typeof options.skip==='function' && options.skip(req,res)) return;
       var line = fmt(exports, req, res);
       if (null == line) return;
       stream.write(line + '\n');

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,19 +1,26 @@
 
-var connect = require('../');
+var connect = require('../'),
+  should = require('should');
 
 var lastLogLine;
 function saveLastLogLine(line) { lastLogLine = line; }
 
 var app = connect();
 
-app.use(connect.logger({'format': 'default', 'stream': {'write': saveLastLogLine}}));
+var loggerOptions = { format: 'default', stream: { write: saveLastLogLine } };
 
+app.use(connect.logger(loggerOptions));
+
+var statusCode = 200;
 app.use(function (req, res) {
+  res.statusCode = statusCode;
   res.end(req.connection.remoteAddress);
 });
 
 describe('connect.logger()', function () {
+
   describe('when Connection: close', function () {
+
     it('should log the client ip', function (done) {
       app.request()
       .get('/')
@@ -22,6 +29,37 @@ describe('connect.logger()', function () {
         lastLogLine.should.startWith(res.body);
         done();
       });
-    })
+    });
+
+    it('should be able to skip based on request', function (done) {
+      loggerOptions.skip = function (req,res){
+        return res.query.skip;
+      };
+      lastLogLine=null;
+      app.request()
+      .get('/?skip=true')
+      .set('Connection', 'close')
+      .end(function (res) {
+        should.not.exist(lastLogLine);
+        done();
+      });
+    });
+
+    it('should be able to skip based on response', function (done) {
+      loggerOptions.skip = function (req,res){
+        return res.statusCode===304;
+      };
+      lastLogLine = null;
+      statusCode = 304;
+      app
+      .request()
+      .get('/')
+      .end(function (res) {
+        should.not.exist(lastLogLine);
+        done();
+      });
+    });
+
   })
+
 });


### PR DESCRIPTION
This came about because of this StackOverflow question: http://stackoverflow.com/questions/21030885.  The OP wanted to be able to log conditionally based on the response status code.  I chose to implement this by testing for the presense of a function called 'skip' in the options object.  If that function is there, it is invoked with the request and response: if its result is truthy, the request is not logged.  Simple and low-impact.
