### PR TITLE
Allow a fallback file option

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -76,7 +76,7 @@ exports = module.exports = function(root, options){
       next(err);
     }
 
-    send(req, path, {fallback:options.fallback})
+    send(req, path, { fallback:options.fallback })
       .maxage(options.maxAge || 0)
       .root(root)
       .index(options.index || 'index.html')

--- a/test/static.js
+++ b/test/static.js
@@ -371,7 +371,7 @@ describe('connect.static()', function(){
   describe('when a fallback is provided', function(){
     it('should serve the fallback if it exists', function(done) {
       var app = connect();
-      app.use(connect.static(fixtures, {fallback:'todo.txt'}));
+      app.use(connect.static(fixtures, { fallback: 'todo.txt' }));
   
       app.use(function(req, res){
         res.statusCode = 404;
@@ -385,7 +385,7 @@ describe('connect.static()', function(){
 
     it('should 404 if the fallback does not exist', function(done) {
       var app = connect();
-      app.use(connect.static(fixtures, {fallback:'still-does-not-exist.txt'}));
+      app.use(connect.static(fixtures, { fallback: 'still-does-not-exist.txt' }));
   
       app.use(function(req, res){
         res.statusCode = 404;


### PR DESCRIPTION
Suppose you are serving profile images, and not all of your users have supplied profile images. Rather than hitting your application code on the image fetch to determine if the image exists, you can specify a default blank avatar.

This PR adds a fallback option that allows users to specify a file path to serve if the originally requested file is not present. If the fallback is also not present, it 404s as normal.

This was inspired by a SO question: http://stackoverflow.com/questions/21198790/how-to-serve-static-profile-images-in-node

This PR does not function without this corresponding PR in send: https://github.com/visionmedia/send/pull/33
