### PR TITLE
Using req.url for dev logger

### DIFF
--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -247,7 +247,7 @@ exports.format('dev', function(tokens, req, res){
     : len = ' - ' + bytes(len);
 
   return '\x1b[90m' + req.method
-    + ' ' + req.originalUrl + ' '
+    + ' ' + (req.originalUrl || req.url) + ' '
     + '\x1b[' + color + 'm' + res.statusCode
     + ' \x1b[90m'
     + (new Date - req._startTime)


### PR DESCRIPTION
When using `:url`, we check for originalUrl or url:

``` javascript
  return req.originalUrl || req.url;
```

Here is the same thing for the `dev` format.
