### PR TITLE
Make log buffer logger instance specific.

### DIFF
--- a/lib/middleware/logger.js
+++ b/lib/middleware/logger.js
@@ -12,12 +12,6 @@
 var bytes = require('bytes');
 
 /*!
- * Log buffer.
- */
-
-var buf = [];
-
-/*!
  * Default log buffer duration.
  */
 
@@ -112,6 +106,7 @@ exports = module.exports = function logger(options) {
   // buffering support
   if (buffer) {
     var realStream = stream
+      , buf = []
       , interval = 'number' == typeof buffer
         ? buffer
         : defaultBufferDuration;


### PR DESCRIPTION
Was skimming the code and noticed this.

As it is now, if a user created two different buffered logger instances with different output streams, the data would randomly get written to one of the two streams.

Threw together a quick example where all the data comes out of the first stream even though it went into two separate loggers.

```
var stream = require('stream');
var http = require('http');
var events = require('events');

var connect = require('connect');

var s = new stream.PassThrough();
var log = connect.logger({
    format: 'app log',
    stream: s,
    buffer: 1,
    immediate: true
});

var s2 = new stream.PassThrough();
var log2 = connect.logger({
    format: 'app2 log',
    stream: s2,
    buffer: 1,
    immediate: true
});

log({socket: {}}, new events.EventEmitter(), function(){});
log2({socket: {}}, new events.EventEmitter(), function(){});

s.on('readable', function(){
    console.log('Stream 1 data:', s.read().toString());
});
s2.on('readable', function(){
    console.log('Stream 2 data:', s2.read().toString());
});
```
