### PR TITLE
Use text/plain as the content type of error messages

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -10,7 +10,6 @@
  */
 
 var http = require('http');
-var escapehtml = require('escape-html');
 var debug = require('debug')('connect:dispatcher');
 var parseUrl = require('parseurl');
 
@@ -142,21 +141,20 @@ app.handle = function(req, res, out) {
         var msg = 'production' == env
           ? http.STATUS_CODES[res.statusCode]
           : err.stack || err.toString();
-        msg = escapehtml(msg);
 
         // log to stderr in a non-test env
         if ('test' != env) console.error(err.stack || err.toString());
         if (res.headersSent) return req.socket.destroy();
-        res.setHeader('Content-Type', 'text/html');
+        res.setHeader('Content-Type', 'text/plain');
         res.setHeader('Content-Length', Buffer.byteLength(msg));
         if ('HEAD' == req.method) return res.end();
         res.end(msg);
       } else {
         debug('default 404');
         res.statusCode = 404;
-        res.setHeader('Content-Type', 'text/html');
+        res.setHeader('Content-Type', 'text/plain');
         if ('HEAD' == req.method) return res.end();
-        res.end('Cannot ' + escapehtml(req.method) + ' ' + escapehtml(req.originalUrl) + '\n');
+        res.end('Cannot ' + req.method + ' ' + req.originalUrl + '\n');
       }
       return;
     }


### PR DESCRIPTION
There are two advantages to this:
1. You don't need to use escape-html on error messages
2. Newlines in error messages and stack traces are visible to the user.

Point 2 is a massive benefit to how quick and easy it is to see error messages.
