### PR TITLE
prevent options object from being passed to qs as delim

### DIFF
--- a/lib/middleware/query.js
+++ b/lib/middleware/query.js
@@ -27,18 +27,16 @@ var qs = require('qs')
  *         res.end(JSON.stringify(req.query));
  *       });
  *
- *  The `options` passed are provided to qs.parse function.
- *
  * @param {Object} options
  * @return {Function}
  * @api public
  */
 
-module.exports = function query(options){
+module.exports = function query(){
   return function query(req, res, next){
     if (!req.query) {
       req.query = ~req.url.indexOf('?')
-        ? qs.parse(parseurl(req).query, options)
+        ? qs.parse(parseurl(req).query)
         : {};
     }
 


### PR DESCRIPTION
As far as I can tell, versions of `qs` prior to 1.0.0, there has never
been an options object parameter to `qs.parse`, however connect has
supported passing such an object to parse since a73dd2bc0e. In `qs` 1.2.0,
which the 2.x branch of connect is currently dependent on, parse takes 3
parameters, and if the second parameter is not a number, it is treated
as the third parameter, the delimiter. As a result, you'll end up with
the object as the delimiter, which isn't good.

What I've done here is remove the ability to pass the options object to
`qs.parse`. If it's there, it will just be ignored. It was never actually
being used anyway.

Support for the new call signature could be added, but I'm guessing
that's more of a 3.x thing. 
