### PR TITLE
deps: remove debug

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -11,7 +11,6 @@
 
 var finalhandler = require('finalhandler');
 var http = require('http');
-var debug = require('debug')('connect:dispatcher');
 var parseUrl = require('parseurl');
 
 // prototype
@@ -71,7 +70,6 @@ app.use = function(route, fn){
   }
 
   // add the middleware
-  debug('use %s %s', route || '/', fn.name || 'anonymous');
   this.stack.push({ route: route, handle: fn });
 
   return this;
@@ -197,8 +195,6 @@ app.listen = function(){
 function call(handle, route, err, req, res, next) {
   var arity = handle.length;
   var hasError = Boolean(err);
-
-  debug('%s %s : %s', handle.name || '<anonymous>', route, req.originalUrl);
 
   try {
     if (hasError && arity === 4) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   ],
   "repository": "senchalabs/connect",
   "dependencies": {
-    "debug": "~2.1.1",
     "finalhandler": "0.3.3",
     "parseurl": "~1.3.0",
     "utils-merge": "1.0.0"


### PR DESCRIPTION
It is extraneous dependency if you do not need debug. Even for debug, it would be better to have events system instead of using `debug` package.