### PR TITLE
Fix Arguments to path.join must be strings

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -126,7 +126,7 @@ var send = exports.send = function(req, res, next, options){
   if (!root && ~path.indexOf('..')) return utils.forbidden(res);
 
   // join / normalize from optional root dir
-  path = normalize(join(root, path));
+  path = normalize(join(root || "", path));
 
   // malicious path
   if (root && 0 != path.indexOf(root)) return fn


### PR DESCRIPTION
Node v0.10 API rules