### PR TITLE
simplify protohost calculation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@ unreleased
     - deps: parseurl@~1.3.3
     - deps: statuses@~1.4.0
   * deps: parseurl@~1.3.3
+  * perf: remove substr call from FQDN mapping
 
 3.6.6 / 2018-02-14
 ==================

--- a/index.js
+++ b/index.js
@@ -271,13 +271,9 @@ function getProtohost(url) {
     return undefined;
   }
 
-  var searchIndex = url.indexOf('?');
-  var pathLength = searchIndex !== -1
-    ? searchIndex
-    : url.length;
-  var fqdnIndex = url.substr(0, pathLength).indexOf('://');
+  var fqdnIndex = url.indexOf('://')
 
-  return fqdnIndex !== -1
+  return fqdnIndex !== -1 && url.lastIndexOf('?', fqdnIndex) === -1
     ? url.substr(0, url.indexOf('/', 3 + fqdnIndex))
     : undefined;
 }


### PR DESCRIPTION
fewer `substr` calls