### PR TITLE
chore: finalhandler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,11 @@ jobs:
 
         - name: Node.js 8.x
           node-version: "8.17"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 9.x
           node-version: "9.11"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 10.x
           node-version: "10.24"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "repository": "senchalabs/connect",
   "dependencies": {
     "debug": "2.6.9",
-    "finalhandler": "1.1.2",
+    "finalhandler": "1.3.0",
     "parseurl": "~1.3.3",
     "utils-merge": "1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "repository": "senchalabs/connect",
   "dependencies": {
     "debug": "2.6.9",
-    "finalhandler": "1.3.0",
+    "finalhandler": "1.3.1",
     "parseurl": "~1.3.3",
     "utils-merge": "1.0.1"
   },


### PR DESCRIPTION
Full HTTP/2 support without deprecation messages

Ref: https://github.com/pillarjs/finalhandler/pull/53