### PR TITLE
build: support Node.js 22.x and 24.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         - Node.js 18.x
         - Node.js 20.x
         - Node.js 21.x
+        - Node.js 22.x
+        - Node.js 24.x
 
         include:
         - name: Node.js 0.10
@@ -118,6 +120,12 @@ jobs:
 
         - name: Node.js 21.x
           node-version: "21.6"
+
+        - name: Node.js 22.x
+          node-version: "22.22"
+
+        - name: Node.js 24.x
+          node-version: "24.13"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
- Node v24 is the active LTS
- Node v22 is maintenance LTS